### PR TITLE
changed endless retry + parallelism

### DIFF
--- a/BlobStorage/host.json
+++ b/BlobStorage/host.json
@@ -1,5 +1,18 @@
 {
   "version": "2.0",
+  "aggregator": {
+    "batchSize": 1,
+    "flushTimeout": "00:00:30"
+  },
+  "retry": {
+    "strategy": "exponentialBackoff",
+    "maxRetryCount": 3, 
+  },
+  "extensions": {
+    "blobs": {
+      "maxDegreeOfParallelism": 1
+    }
+  },
   "logging": {
     "applicationInsights": {
       "samplingSettings": {


### PR DESCRIPTION
changed endless retry to 3 with exponential backoff time
added maxDegreeOfParallelism of 1  to limit the risk of race condition on same log assets
changed batch size to 1 to keep resource consumption low on high yield aggregates .