### PR TITLE
Workspace-based Application Insights

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: 18
       
       - name: install AWS cli
         run: |

--- a/BlobViaEventGrid/ARM/BlobViaEventGrid.json
+++ b/BlobViaEventGrid/ARM/BlobViaEventGrid.json
@@ -139,17 +139,34 @@
       }
     },
     {
-      "type": "Microsoft.Insights/components",
-      "apiVersion": "2020-02-02",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-08-01",
       "name": "[variables('applicationInsightsName')]",
-      "location": "[variables('functionAppLocation')]",
-      "tags": {
-        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
-      },
+      "location": "[variables('location')]",
       "properties": {
-        "Application_Type": "web"
+          "sku": {
+              "name": "PerGB2018"
+          },
+          "retentionInDays": "90"
       },
-      "kind": "web"
+      "resources": [
+        {
+          "type": "Microsoft.Insights/components",
+          "apiVersion": "2020-02-02",
+          "name": "[variables('applicationInsightsName')]",
+          "location": "[variables('location')]",
+          "properties": {
+            "ApplicationId": "[variables('applicationInsightsName')]",
+            "Application_Type": "web",
+            "Flow_Type": "Bluefield",
+            "Request_Source": "rest",
+            "WorkspaceResourceId": "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          },
+          "dependsOn": [
+            "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          ]
+        }
+      ]
     },
     {
       "type": "Microsoft.Web/sites",

--- a/BlobViaEventGrid/CHANGELOG.md
+++ b/BlobViaEventGrid/CHANGELOG.md
@@ -4,3 +4,6 @@
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 2.0.0 / 21 Feb 2023
+[Update/Breaking] Replacing "Classic" Application Insights with Workspace-Based Application Insights.

--- a/BlobViaEventGrid/package.json
+++ b/BlobViaEventGrid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/BlobViaEventGrid/package.json
+++ b/BlobViaEventGrid/package.json
@@ -57,8 +57,8 @@
     "url": "https://github.com/coralogix/coralogix-azure-serverless/issues"
   },
   "devDependencies": {
-    "@azure/functions": ">=3.5.0",
-    "@types/node": "^18.15.3",
+    "@azure/functions": "^3.5.1",
+    "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": ">=5.48.2",
     "@typescript-eslint/parser": ">=5.48.2",
     "eslint": ">=8.32.0",

--- a/DiagnosticData/ARM/DiagnosticData.json
+++ b/DiagnosticData/ARM/DiagnosticData.json
@@ -114,17 +114,34 @@
       }
     },
     {
-      "type": "Microsoft.Insights/components",
-      "apiVersion": "2020-02-02",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-08-01",
       "name": "[variables('applicationInsightsName')]",
       "location": "[variables('location')]",
-      "tags": {
-        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
-      },
       "properties": {
-        "Application_Type": "web"
+          "sku": {
+              "name": "PerGB2018"
+          },
+          "retentionInDays": "90"
       },
-      "kind": "web"
+      "resources": [
+        {
+          "type": "Microsoft.Insights/components",
+          "apiVersion": "2020-02-02",
+          "name": "[variables('applicationInsightsName')]",
+          "location": "[variables('location')]",
+          "properties": {
+            "ApplicationId": "[variables('applicationInsightsName')]",
+            "Application_Type": "web",
+            "Flow_Type": "Bluefield",
+            "Request_Source": "rest",
+            "WorkspaceResourceId": "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          },
+          "dependsOn": [
+            "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          ]
+        }
+      ]
     },
     {
       "type": "Microsoft.Web/sites",

--- a/DiagnosticData/CHANGELOG.md
+++ b/DiagnosticData/CHANGELOG.md
@@ -4,3 +4,6 @@
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 2.0.0 / 21 Feb 2023
+[Update/Breaking] Replacing "Classic" Application Insights with Workspace-Based Application Insights.

--- a/DiagnosticData/package.json
+++ b/DiagnosticData/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/EventHub/ARM/EventHub.json
+++ b/EventHub/ARM/EventHub.json
@@ -4,7 +4,7 @@
   "parameters": {
     "CoralogixRegion": {
       "type": "string",
-      "defaultValue": "Europe",
+      "defaultValue": "Europe(eu-west-1)",
       "allowedValues": [
         "Europe(eu-west-1)",
         "US(us-east-2)",
@@ -114,17 +114,34 @@
       }
     },
     {
-      "type": "Microsoft.Insights/components",
-      "apiVersion": "2020-02-02",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-08-01",
       "name": "[variables('applicationInsightsName')]",
       "location": "[variables('location')]",
-      "tags": {
-        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
-      },
       "properties": {
-        "Application_Type": "web"
+          "sku": {
+              "name": "PerGB2018"
+          },
+          "retentionInDays": "90"
       },
-      "kind": "web"
+      "resources": [
+        {
+          "type": "Microsoft.Insights/components",
+          "apiVersion": "2020-02-02",
+          "name": "[variables('applicationInsightsName')]",
+          "location": "[variables('location')]",
+          "properties": {
+            "ApplicationId": "[variables('applicationInsightsName')]",
+            "Application_Type": "web",
+            "Flow_Type": "Bluefield",
+            "Request_Source": "rest",
+            "WorkspaceResourceId": "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          },
+          "dependsOn": [
+            "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          ]
+        }
+      ]
     },
     {
       "type": "Microsoft.Web/sites",

--- a/EventHub/CHANGELOG.md
+++ b/EventHub/CHANGELOG.md
@@ -4,3 +4,6 @@
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 2.0.0 / 21 Feb 2023
+[Update/Breaking] Replacing "Classic" Application Insights with Workspace-Based Application Insights.

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -55,8 +55,8 @@
     "url": "https://github.com/coralogix/coralogix-azure-serverless/issues"
   },
   "devDependencies": {
-    "@azure/functions": ">=3.5.0",
-    "@types/node": ">=18.11.18",
+    "@azure/functions": "^3.5.1",
+    "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": ">=5.48.2",
     "@typescript-eslint/parser": ">=5.48.2",
     "eslint": ">=8.32.0",

--- a/StorageQueue/ARM/StorageQueue.json
+++ b/StorageQueue/ARM/StorageQueue.json
@@ -108,17 +108,34 @@
       }
     },
     {
-      "type": "Microsoft.Insights/components",
-      "apiVersion": "2020-02-02",
+      "type": "Microsoft.OperationalInsights/workspaces",
+      "apiVersion": "2020-08-01",
       "name": "[variables('applicationInsightsName')]",
       "location": "[variables('location')]",
-      "tags": {
-        "[format('hidden-link:{0}', resourceId('Microsoft.Web/sites', variables('applicationInsightsName')))]": "Resource"
-      },
       "properties": {
-        "Application_Type": "web"
+          "sku": {
+              "name": "PerGB2018"
+          },
+          "retentionInDays": "90"
       },
-      "kind": "web"
+      "resources": [
+        {
+          "type": "Microsoft.Insights/components",
+          "apiVersion": "2020-02-02",
+          "name": "[variables('applicationInsightsName')]",
+          "location": "[variables('location')]",
+          "properties": {
+            "ApplicationId": "[variables('applicationInsightsName')]",
+            "Application_Type": "web",
+            "Flow_Type": "Bluefield",
+            "Request_Source": "rest",
+            "WorkspaceResourceId": "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          },
+          "dependsOn": [
+            "[resourceId(resourceGroup().name, 'Microsoft.OperationalInsights/workspaces', variables('applicationInsightsName'))]"
+          ]
+        }
+      ]
     },
     {
       "type": "Microsoft.Web/sites",

--- a/StorageQueue/CHANGELOG.md
+++ b/StorageQueue/CHANGELOG.md
@@ -4,3 +4,6 @@
 <!-- To add a new entry write: -->
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
+
+### 2.0.0 / 21 Feb 2023
+[Update/Breaking] Replacing "Classic" Application Insights with Workspace-Based Application Insights.

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -49,8 +49,8 @@
     "url": "https://github.com/coralogix/coralogix-azure-serverless/issues"
   },
   "devDependencies": {
-    "@azure/functions": ">=3.5.0",
-    "@types/node": ">=18.11.18",
+    "@azure/functions": "^3.5.1",
+    "@types/node": "^18.15.11",
     "@typescript-eslint/eslint-plugin": ">=5.48.2",
     "@typescript-eslint/parser": ">=5.48.2",
     "eslint": ">=8.32.0",


### PR DESCRIPTION
# Description

Azure is ending support for "Classic" Application Insights. All Integrations have to be moved to the new Workspace-based Application Insights.

Fixes #
CDS-1047

# How Has This Been Tested?

Tested with manual deployment of EventHub ARM template to Azure.

# Checklist:
- [x] I have updated the version in the relevant file.
- [x] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)