### PR TITLE
fix package type for StorageQueue

### DIFF
--- a/StorageQueue/ARM/StorageQueue.json
+++ b/StorageQueue/ARM/StorageQueue.json
@@ -189,8 +189,8 @@
               "value": "[parameters('CoralogixSubsystem')]"
             },
             {
-              "Name": "CORALOGIX_URL",
-              "Value": "[variables('CoralogixURL')]"
+              "name": "CORALOGIX_URL",
+              "value": "[variables('CoralogixURL')]"
             },
             {
               "name": "STORAGE_QUEUE_CONNECT_STRING",

--- a/StorageQueue/CHANGELOG.md
+++ b/StorageQueue/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 2.0.3 / 19 Feb 2026
+[Bug] Fix the package type from `module` to `commonjs`
+[Bug] Update ARM template (parameter case matching)
+
 ### 2.0.2 / 25 Apr 2025
 [Update] Bump Node.js runtime to version 20
 

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "type": "commonjs",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -2,7 +2,7 @@
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
   "version": "2.0.1",
-  "type": "module",
+  "type": "commonjs",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Description

Fixes the execution of `StorageQueue`. The current master version throws this error on each execution:

```
Result: Failure Type: Exception: Worker was unable to load function StorageQueue: 'exports is not defined in ES module scope This file is being treated as an ES module because it has a '.js' file extension and '/home/site/wwwroot/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.' Stack: ReferenceError: Worker was unable to load function StorageQueue: 'exports is not defined in ES module scope This file is being treated as an ES module because it has a '.js' file extension and '/home/site/wwwroot/package.json' contains "type": "module". To treat it as a CommonJS script, rename it to use the '.cjs' file extension.' at file:///home/site/wwwroot/dist/StorageQueue/index.js:11:23 at ModuleJob.run (node:internal/modules/esm/module_job:325:25) at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
```

Switching the package type from `module` to `commonjs` solves this problem.

Also, this PR will fix the parameter case in ARM template, starting attributes from lowercase as it is for other attributes.

# How Has This Been Tested?

Deployed to my Azure function to ensure this will solve the problem.

# Checklist:
- [x] I have updated the version in the relevant file.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)