### PR TITLE
E2E Tests: Stage 1

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,109 @@
+# E2E Tests for all packages (StorageQueue, EventHub, DiagnosticData, BlobViaEventGrid, BlobToOtel).
+#
+# Required GitHub Secrets:
+#   Azure: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
+#   Coralogix: OTEL_ENDPOINT, CORALOGIX_API_KEY, CORALOGIX_QUERY_API_KEY (optional, falls back to CORALOGIX_API_KEY)
+#
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - master
+      - e2e
+    paths:
+      - "StorageQueue/**"
+      - "EventHub/**"
+      - "DiagnosticData/**"
+      - "BlobViaEventGrid/**"
+      - "BlobToOtel/**"
+  schedule:
+    # Every morning 8am UTC
+    - cron: "0 8 * * *"
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      packages: ${{ steps.set-packages.outputs.packages }}
+      has-changes: ${{ steps.set-packages.outputs.has-changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        if: github.event_name != 'schedule'
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed packages
+        uses: dorny/paths-filter@v3
+        id: changes
+        if: github.event_name == 'push'
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            StorageQueue:
+              - 'StorageQueue/**'
+            EventHub:
+              - 'EventHub/**'
+            DiagnosticData:
+              - 'DiagnosticData/**'
+            BlobViaEventGrid:
+              - 'BlobViaEventGrid/**'
+            BlobToOtel:
+              - 'BlobToOtel/**'
+
+      - name: Set packages matrix
+        id: set-packages
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref }}" == "refs/heads/e2e" ]]; then
+            echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
+            echo 'has-changes=true' >> $GITHUB_OUTPUT
+          else
+            packages='${{ steps.changes.outputs.changes }}'
+            echo "packages=$packages" >> $GITHUB_OUTPUT
+            if [[ "$packages" == "[]" ]] || [[ -z "$packages" ]]; then
+              echo 'has-changes=false' >> $GITHUB_OUTPUT
+            else
+              echo 'has-changes=true' >> $GITHUB_OUTPUT
+            fi
+          fi
+
+  e2e:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has-changes == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        package: ${{ fromJson(needs.detect-changes.outputs.packages) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.4"
+
+      - name: Setup Python (EventHub e2e)
+        if: matrix.package == 'EventHub'
+        run: pip install azure-eventhub
+
+      - name: Azure Login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        env:
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+
+      - name: Run E2E test
+        working-directory: ./${{ matrix.package }}/tests
+        env:
+          OTEL_ENDPOINT: ${{ secrets.OTEL_ENDPOINT }}
+          CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
+          CORALOGIX_QUERY_API_KEY: ${{ secrets.CORALOGIX_QUERY_API_KEY }}
+          CORALOGIX_DIRECT_MODE: "true"
+        run: ./e2e.sh

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,6 +17,9 @@ on:
 #     # Every morning 8am UTC
 #     - cron: "0 8 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   detect-changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,25 +1,21 @@
-# E2E Tests for all packages (StorageQueue, EventHub, DiagnosticData, BlobViaEventGrid, BlobToOtel).
-#
-# Required GitHub Secrets:
-#   Azure: AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID
-#   Coralogix: OTEL_ENDPOINT, CORALOGIX_API_KEY, CORALOGIX_QUERY_API_KEY (optional, falls back to CORALOGIX_API_KEY)
-#
 name: E2E Tests
 
 on:
   push:
     branches:
-      - master
-      - e2e
+    # Uncomment after Stage 2
+    #   - master
+      - e2e-stage2
     paths:
       - "StorageQueue/**"
       - "EventHub/**"
       - "DiagnosticData/**"
       - "BlobViaEventGrid/**"
       - "BlobToOtel/**"
-  schedule:
-    # Every morning 8am UTC
-    - cron: "0 8 * * *"
+# Uncomment after Stage 2
+#   schedule:
+#     # Every morning 8am UTC
+#     - cron: "0 8 * * *"
 
 jobs:
   detect-changes:
@@ -55,7 +51,8 @@ jobs:
       - name: Set packages matrix
         id: set-packages
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref }}" == "refs/heads/e2e" ]]; then
+          # Delete 2nd part of the if statement after Stage 2
+          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref }}" == "refs/heads/e2e-stage2" ]]; then
             echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
             echo 'has-changes=true' >> $GITHUB_OUTPUT
           else

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,11 @@ venv.bak/
 __pycache__/
 *.py[cod]
 *$py.class
+
+# Terraform (e2e tests per Azure function)
+**/.terraform/
+**/*.tfstate
+**/*.tfstate.*
+**/crash.log
+**/crash.*.log
+**/.terraform.lock.hcl

--- a/BlobToOtel/tests/.gitignore
+++ b/BlobToOtel/tests/.gitignore
@@ -1,0 +1,11 @@
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/*.tfvars
+!terraform/*.tfvars.example
+
+# E2E generated
+arm-params.json
+.e2e-test-payload.tmp

--- a/BlobToOtel/tests/README.md
+++ b/BlobToOtel/tests/README.md
@@ -1,0 +1,81 @@
+# BlobToOtel E2E tests
+
+End-to-end test for the BlobToOtel Azure Function: provision prereqs + Event Hub consumer group with Terraform, deploy the function via ARM (latest master), trigger with a test blob, then clean up.
+
+## Flow
+
+1. **Provision** – Terraform creates resource group, storage account, container, Event Hub, Event Grid subscription (blob created → Event Hub), and an Event Hub consumer group for the function.
+2. **ARM deploy** – The [BlobToOtel ARM template](https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobToOtel/ARM/BlobToOtel.json) is deployed with Azure CLI; all parameters are set explicitly from the resources created in step 1 (including the consumer group name).
+3. **Test payload** – A small blob is uploaded to the container; Event Grid sends the event to Event Hub and the function runs.
+4. **Verify** – After 30s the script polls the Coralogix Get Logs Count API (last 10 min, 10m resolution) for app=azure, subsystem=blob-storage-logs. If count is 0, it retries every 30s up to 10 times; if count &gt; 0, it proceeds. Requires an API key with Data Usage read permission.
+5. **Cleanup** – Resource group is deleted and Terraform state is cleared.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+- [Terraform](https://www.terraform.io/downloads) >= 1.7.4.
+- [jq](https://jqlang.github.io/jq/) (for Step 4 verification).
+
+**Azure login** – The script logs in automatically if you set:
+
+- **Service principal** (CI/non-interactive): `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
+- **Managed identity** (e.g. running inside Azure): `AZURE_USE_MANAGED_IDENTITY=1`
+
+Otherwise run `az login` once before `./e2e.sh`.
+
+## Usage
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"   # or your OTLP endpoint
+export CORALOGIX_QUERY_API_KEY="..." # – for Step 4 (Data Usage read)
+export CORALOGIX_API_KEY="..." 
+
+# Optional (defaults shown):
+# export CORALOGIX_DIRECT_MODE=false
+# export CORALOGIX_APPLICATION=azure
+# export CORALOGIX_SUBSYSTEM=blob-storage-logs
+
+./e2e.sh
+```
+
+For Coralogix direct mode (OTLP to Coralogix):
+
+```bash
+export OTEL_ENDPOINT="https://ingress.coralogix.com"
+export CORALOGIX_DIRECT_MODE=true
+export CORALOGIX_API_KEY="your-send-your-data-api-key"
+export CORALOGIX_QUERY_API_KEY="your-query-api-key" # – for Step 4 (Data Usage read)
+./e2e.sh
+```
+
+## Terraform
+
+The `terraform/` directory contains a root module that:
+
+- Creates a resource group, storage account, and blob container.
+- Creates an Event Hub namespace and Event Hub.
+- Creates an Event Grid event subscription so `Microsoft.Storage.BlobCreated` events are sent to the Event Hub.
+- Creates an Event Hub consumer group (used by the ARM-deployed function).
+
+All names and the region are hardcoded in `main.tf` for the e2e test.
+
+## Verifying logs in Coralogix (Get Logs Count API)
+
+To check that logs arrived for the e2e app/subsystem, use the [Get Logs Count](https://docs.coralogix.com/api-reference/latest/data-usage-service/get-logs-count) API. Pass the date range as **flat query parameters** (`date_range.fromDate`, `date_range.toDate`) in ISO 8601 format, not as a single JSON object:
+
+```bash
+# Last 1 hour; use application/subsystem from e2e (azure / blob-storage-logs)
+FROM_DATE=$(date -u -v-1H +%Y-%m-%dT%H:%M:%S.000Z)
+TO_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+curl -s -G "https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count" \
+  --data-urlencode "date_range.fromDate=$FROM_DATE" \
+  --data-urlencode "date_range.toDate=$TO_DATE" \
+  --data-urlencode "resolution=1h" \
+  --data-urlencode "filters.application=azure" \
+  --data-urlencode "filters.subsystem=blob-storage-logs" \
+  --data-urlencode "subsystem_aggregation=true" \
+  -H "Authorization: Bearer $CX_API_KEY"
+```
+
+Use the same region as your OTEL endpoint (e.g. `api.eu2.coralogix.com` for EU2). The API key needs Data Usage read permission (e.g. DataUsage preset).

--- a/BlobToOtel/tests/check_logs.sh
+++ b/BlobToOtel/tests/check_logs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_OPEN_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+# sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Step 4: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# E2E test for BlobToOtel Azure Function.
+#
+# Order of execution:
+#   1. Provision Azure resources with Terraform (prereqs + Event Hub consumer group).
+#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   3. Send a test payload (upload a blob to trigger the function).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   5. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Environment variables (or export before running):
+#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.coralogix.com
+#     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
+#     - Optional: CORALOGIX_DIRECT_MODE, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobToOtel/ARM/BlobToOtel.json"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Provision with Terraform ---
+log "Step 1: Provisioning Azure resources with Terraform (prereqs + Event Hub consumer group)..."
+cd "$TERRAFORM_DIR"
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
+EVENTHUB_NAME=$(terraform output -raw eventhub_name)
+EVENTHUB_RG=$(terraform output -raw eventhub_resource_group)
+EVENTHUB_CONSUMER_GROUP=$(terraform output -raw eventhub_consumer_group_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, ConsumerGroup=$EVENTHUB_CONSUMER_GROUP"
+
+# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+log "Step 2: Deploying ARM template from master with explicit parameters..."
+PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
+# Build parameters JSON with explicit values (no defaults); escape quotes in values.
+build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
+{
+  echo '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#", "contentVersion": "1.0.0.0", "parameters": {'
+  echo "  $(build_param 'OtelEndpoint' "$OTEL_ENDPOINT"),"
+  echo "  $(build_param 'CoralogixDirectMode' "${CORALOGIX_DIRECT_MODE:-false}"),"
+  echo "  $(build_param 'CoralogixApiKey' "${CORALOGIX_API_KEY:-}"),"
+  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
+  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"),"
+  echo '  "NewlinePattern": { "value": "(?:\\r\\n|\\r|\\n)" },'
+  echo "  $(build_param 'EventHubNamespace' "$EVENTHUB_NAMESPACE"),"
+  echo "  $(build_param 'EventHubName' "$EVENTHUB_NAME"),"
+  echo "  $(build_param 'EventHubResourceGroup' "$EVENTHUB_RG"),"
+  echo "  $(build_param 'StorageAccountName' "$STORAGE_ACCOUNT"),"
+  echo "  $(build_param 'StorageAccountResourceGroup' "$STORAGE_RG"),"
+  echo "  $(build_param 'PrefixFilter' "${PREFIX_FILTER:-NoFilter}"),"
+  echo "  $(build_param 'SuffixFilter' "${SUFFIX_FILTER:-NoFilter}"),"
+  echo "  $(build_param 'FunctionAppServicePlanType' "${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"),"
+  echo '  "VirtualNetworkName": { "value": "" },'
+  echo '  "SubnetName": { "value": "" },'
+  echo '  "VirtualNetworkResourceGroup": { "value": "" },'
+  echo '  "NodeHeapSize": { "value": 2048 },'
+  echo "  $(build_param 'EventHubConsumerGroup' "$EVENTHUB_CONSUMER_GROUP"),"
+  echo '  "MaxElasticWorkerCount": { "value": 5 },'
+  echo '  "PremiumPlanSku": { "value": "EP1" }'
+  echo '} }'
+} > "$PARAMS_FILE"
+
+az deployment group create \
+  --resource-group "$RG_NAME" \
+  --template-uri "$ARM_TEMPLATE_URI" \
+  --parameters "@${PARAMS_FILE}"
+
+rm -f "$PARAMS_FILE"
+log "ARM deployment completed."
+
+# --- Step 3: Send test payload (upload blob to trigger function) ---
+log "Step 3: Uploading test blob to trigger the function..."
+TEST_BLOB_NAME="e2e-test-$(date +%s).log"
+TEST_BLOB_FILE="${SCRIPT_DIR}/.e2e-test-payload.tmp"
+printf 'e2e test line 1\ne2e test line 2\ne2e test line 3\n' > "$TEST_BLOB_FILE"
+az storage blob upload \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --container-name "$CONTAINER_NAME" \
+  --name "$TEST_BLOB_NAME" \
+  --file "$TEST_BLOB_FILE" \
+  --type block \
+  --content-type "text/plain" \
+  --no-progress
+rm -f "$TEST_BLOB_FILE"
+
+log "Uploaded test blob: $CONTAINER_NAME/$TEST_BLOB_NAME"
+
+# --- Step 4: Verify logs landed in Coralogix (poll Get Logs Count API) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 4: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 5: Clean up ---
+log "Step 5: Cleaning up resources..."
+trap - EXIT
+# Delete the entire resource group (removes Terraform and ARM-created resources).
+az group delete --name "$RG_NAME" --yes
+log "Waiting for resource group deletion..."
+while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# Clean Terraform state so next run can provision from scratch.
+cd "$TERRAFORM_DIR"
+while read -r state_key; do
+  [[ -z "$state_key" ]] && continue
+  terraform state rm "$state_key" 2>/dev/null || true
+done < <(terraform state list 2>/dev/null || true)
+log "E2E test finished."

--- a/BlobToOtel/tests/terraform/main.tf
+++ b/BlobToOtel/tests/terraform/main.tf
@@ -71,10 +71,10 @@ resource "azurerm_eventhub" "hub" {
 
 # Route blob-created events from storage to Event Hub
 resource "azurerm_eventgrid_event_subscription" "storage_to_eventhub" {
-  name                  = "${local.name_prefix}-storage-to-eh"
-  scope                 = azurerm_storage_account.blob.id
-  eventhub_endpoint_id  = azurerm_eventhub.hub.id
-  included_event_types  = ["Microsoft.Storage.BlobCreated"]
+  name                 = "${local.name_prefix}-storage-to-eh"
+  scope                = azurerm_storage_account.blob.id
+  eventhub_endpoint_id = azurerm_eventhub.hub.id
+  included_event_types = ["Microsoft.Storage.BlobCreated"]
 }
 
 # Consumer group for the ARM-deployed BlobToOtel function

--- a/BlobToOtel/tests/terraform/main.tf
+++ b/BlobToOtel/tests/terraform/main.tf
@@ -1,0 +1,86 @@
+# Prerequisites for BlobToOtel: resource group, storage account, container,
+# Event Hub, Event Grid subscription (storage blob created -> Event Hub),
+# and an Event Hub consumer group for the ARM-deployed function.
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "blobtootel-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test (prereqs; function is deployed via ARM)
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+# Storage account for blob container (source of log blobs)
+resource "azurerm_storage_account" "blob" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+resource "azurerm_storage_container" "logs" {
+  name                  = "logs"
+  storage_account_name  = azurerm_storage_account.blob.name
+  container_access_type = "private"
+}
+
+# Event Hub namespace and hub (destination for blob-created events)
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+resource "azurerm_eventhub" "hub" {
+  name                = "blob-events"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+# Route blob-created events from storage to Event Hub
+resource "azurerm_eventgrid_event_subscription" "storage_to_eventhub" {
+  name                  = "${local.name_prefix}-storage-to-eh"
+  scope                 = azurerm_storage_account.blob.id
+  eventhub_endpoint_id  = azurerm_eventhub.hub.id
+  included_event_types  = ["Microsoft.Storage.BlobCreated"]
+}
+
+# Consumer group for the ARM-deployed BlobToOtel function
+resource "azurerm_eventhub_consumer_group" "blobtootel" {
+  name                = "blobtootel-e2e"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  eventhub_name       = azurerm_eventhub.hub.name
+  resource_group_name = azurerm_resource_group.e2e.name
+}

--- a/BlobToOtel/tests/terraform/outputs.tf
+++ b/BlobToOtel/tests/terraform/outputs.tf
@@ -1,0 +1,50 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for ARM deployment and cleanup."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.blob.name
+  description = "Storage account name (for ARM parameter StorageAccountName)."
+}
+
+output "storage_account_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the storage account (for ARM parameter StorageAccountResourceGroup)."
+}
+
+output "blob_container_name" {
+  value       = azurerm_storage_container.logs.name
+  description = "Blob container name for uploading test payload."
+}
+
+output "eventhub_namespace" {
+  value       = azurerm_eventhub_namespace.ns.name
+  description = "Event Hub namespace (for ARM parameter EventHubNamespace)."
+}
+
+output "eventhub_name" {
+  value       = azurerm_eventhub.hub.name
+  description = "Event Hub name (for ARM parameter EventHubName)."
+}
+
+output "eventhub_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the Event Hub (for ARM parameter EventHubResourceGroup)."
+}
+
+output "eventhub_consumer_group_name" {
+  value       = azurerm_eventhub_consumer_group.blobtootel.name
+  description = "Event Hub consumer group name (for ARM parameter EventHubConsumerGroup)."
+}
+
+output "storage_account_connection_string" {
+  value       = azurerm_storage_account.blob.primary_connection_string
+  description = "Storage account connection string for uploading test blob."
+  sensitive   = true
+}

--- a/BlobViaEventGrid/tests/README.md
+++ b/BlobViaEventGrid/tests/README.md
@@ -1,0 +1,72 @@
+# BlobViaEventGrid E2E tests
+
+End-to-end test for the BlobViaEventGrid Azure Function: provision prereqs with Terraform (resource group, StorageV2 account, container), deploy the function via ARM (latest master), trigger with a test blob via Event Grid, then clean up.
+
+## Flow
+
+1. **Provision** – Terraform creates resource group, StorageV2 storage account, and blob container. No Event Hub; Event Grid system topic and subscription are created by the ARM template.
+2. **ARM deploy** – The [BlobViaEventGrid ARM template](https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobViaEventGrid/ARM/BlobViaEventGrid.json) is deployed with Azure CLI. It creates the function app and, in the storage resource group, an Event Grid system topic plus an event subscription that sends `Microsoft.Storage.BlobCreated` to the function.
+3. **Test payload** – A small blob is uploaded to the container; Event Grid delivers the event to the function, which processes the blob and sends logs to Coralogix (OTLP).
+4. **Verify** – After 30s the script polls the Coralogix Get Logs Count API (last 10 min, 10m resolution) for `app=azure`, `subsystem=blob-storage-logs`. If count is 0, it retries every 30s up to 10 times; if count > 0, it proceeds. Requires an API key with Data Usage read permission.
+5. **Cleanup** – Resource group is deleted and Terraform state is cleared.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+- [Terraform](https://www.terraform.io/downloads) >= 1.7.4.
+- [jq](https://jqlang.github.io/jq/) (for Step 4 verification).
+
+**Azure login** – The script logs in automatically if you set:
+
+- **Service principal** (CI/non-interactive): `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
+- **Managed identity** (e.g. running inside Azure): `AZURE_USE_MANAGED_IDENTITY=1`
+
+Otherwise run `az login` once before `./e2e.sh`.
+
+## Usage
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"   # or your OTLP endpoint
+export CORALOGIX_API_KEY="..."       # Send your data / Private key (for the function)
+export CORALOGIX_QUERY_API_KEY="..." # For Step 4 (Data Usage read); can equal CORALOGIX_API_KEY
+
+# Optional (defaults shown):
+# export CORALOGIX_APPLICATION=azure
+# export CORALOGIX_SUBSYSTEM=blob-storage-logs
+
+./e2e.sh
+```
+
+## Terraform
+
+The `terraform/` directory contains a root module that:
+
+- Creates a resource group, a **StorageV2** (general purpose v2) storage account, and a blob container.
+- Does **not** create Event Hub or Event Grid resources; the ARM template creates the Event Grid system topic and event subscription that invoke the function when blobs are created.
+
+All names and the region are hardcoded in `main.tf` for the e2e test.
+
+## Verifying logs in Coralogix (Get Logs Count API)
+
+To check that logs arrived for the e2e app/subsystem, use the [Get Logs Count](https://docs.coralogix.com/api-reference/latest/data-usage-service/get-logs-count) API. Pass the date range as **flat query parameters** (`date_range.fromDate`, `date_range.toDate`) in ISO 8601 format:
+
+```bash
+FROM_DATE=$(date -u -v-1H +%Y-%m-%dT%H:%M:%S.000Z)
+TO_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+curl -s -G "https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count" \
+  --data-urlencode "date_range.fromDate=$FROM_DATE" \
+  --data-urlencode "date_range.toDate=$TO_DATE" \
+  --data-urlencode "resolution=1h" \
+  --data-urlencode "filters.application=azure" \
+  --data-urlencode "filters.subsystem=blob-storage-logs" \
+  --data-urlencode "subsystem_aggregation=true" \
+  -H "Authorization: Bearer $CX_API_KEY"
+```
+
+Use the same region as your OTEL endpoint (e.g. `api.eu2.coralogix.com` for EU2). The API key needs Data Usage read permission.
+
+## Difference from BlobToOtel E2E
+
+- **BlobViaEventGrid** is triggered by **Event Grid** (blob created → Event Grid system topic → function). Terraform only provisions storage + container; the ARM template creates the Event Grid system topic and subscription.
+- **BlobToOtel** is triggered via **Event Hub** (blob created → Event Grid subscription → Event Hub → function). Terraform provisions storage, Event Hub, Event Grid subscription to Event Hub, and a consumer group; the ARM template deploys the function with an Event Hub trigger.

--- a/BlobViaEventGrid/tests/check_logs.sh
+++ b/BlobViaEventGrid/tests/check_logs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for app=azure, subsystem=blob-storage-logs (same as e2e.sh verification).
+# Requires: CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally CX_LOGS_COUNT_URL or OTEL_ENDPOINT to derive API host.
+
+if [[ -n "${CX_LOGS_COUNT_URL:-}" ]]; then
+  :
+elif [[ -n "${OTEL_ENDPOINT:-}" ]]; then
+  CX_API_HOST="${OTEL_ENDPOINT#*://}"
+  CX_API_HOST="${CX_API_HOST%%:*}"
+  CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+  CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+else
+  CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+fi
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+# sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+#
+# E2E test for BlobViaEventGrid Azure Function.
+#
+# Order of execution:
+#   1. Provision Azure resources with Terraform (resource group, StorageV2 account, container).
+#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#      The ARM template creates the Event Grid system topic and subscription to the function.
+#   3. Send a test payload (upload a blob to trigger Event Grid → function).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   5. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Environment variables (or export before running):
+#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.coralogix.com
+#     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
+#     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
+#     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobViaEventGrid/ARM/BlobViaEventGrid.json"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+# For Step 4 verification
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Provision with Terraform ---
+log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, container)..."
+cd "$TERRAFORM_DIR"
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME"
+
+# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+log "Step 2: Deploying ARM template from master (function + Event Grid system topic and subscription)..."
+PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
+# Build parameters JSON; escape quotes in values.
+build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
+{
+  echo '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#", "contentVersion": "1.0.0.0", "parameters": {'
+  echo '  "CoralogixRegion": { "value": "Custom" },'
+  echo "  $(build_param 'CustomURL' "$OTEL_ENDPOINT"),"
+  echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
+  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
+  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"),"
+  echo "  $(build_param 'StorageAccountName' "$STORAGE_ACCOUNT"),"
+  echo "  $(build_param 'StorageAccountResourceGroup' "$STORAGE_RG"),"
+  echo "  $(build_param 'BlobContainerName' "$CONTAINER_NAME"),"
+  echo '  "EventGridSystemTopicName": { "value": "cxEventGridTopic" },'
+  echo '  "NewlinePattern": { "value": "(?:\\\\r\\\\n|\\\\r|\\\\n)" },'
+  echo '  "PrefixFilter": { "value": "NoFilter" },'
+  echo '  "SuffixFilter": { "value": "NoFilter" },'
+  echo "  $(build_param 'FunctionAppServicePlanType' "${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"),"
+  echo '  "DebugMode": { "value": "false" },'
+  echo '  "EnableBlobMetadata": { "value": "false" }'
+  echo '} }'
+} > "$PARAMS_FILE"
+
+az deployment group create \
+  --resource-group "$RG_NAME" \
+  --template-uri "$ARM_TEMPLATE_URI" \
+  --parameters "@${PARAMS_FILE}"
+
+rm -f "$PARAMS_FILE"
+log "ARM deployment completed."
+
+# --- Step 3: Send test payload (upload blob to trigger Event Grid → function) ---
+log "Step 3: Uploading test blob to trigger Event Grid and the function..."
+TEST_BLOB_NAME="e2e-test-$(date +%s).log"
+TEST_BLOB_FILE="${SCRIPT_DIR}/.e2e-test-payload.tmp"
+printf 'e2e test line 1\ne2e test line 2\ne2e test line 3\n' > "$TEST_BLOB_FILE"
+az storage blob upload \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --container-name "$CONTAINER_NAME" \
+  --name "$TEST_BLOB_NAME" \
+  --file "$TEST_BLOB_FILE" \
+  --type block \
+  --content-type "text/plain" \
+  --no-progress
+rm -f "$TEST_BLOB_FILE"
+
+log "Uploaded test blob: $CONTAINER_NAME/$TEST_BLOB_NAME"
+
+# --- Step 4: Verify logs landed in Coralogix (poll Get Logs Count API) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 4: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 5: Clean up ---
+log "Step 5: Cleaning up resources..."
+trap - EXIT
+az group delete --name "$RG_NAME" --yes
+log "Waiting for resource group deletion..."
+while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# Clean Terraform state so next run can provision from scratch.
+cd "$TERRAFORM_DIR"
+while read -r state_key; do
+  [[ -z "$state_key" ]] && continue
+  terraform state rm "$state_key" 2>/dev/null || true
+done < <(terraform state list 2>/dev/null || true)
+log "E2E test finished."

--- a/BlobViaEventGrid/tests/terraform/main.tf
+++ b/BlobViaEventGrid/tests/terraform/main.tf
@@ -1,0 +1,53 @@
+# Prerequisites for BlobViaEventGrid E2E: resource group, StorageV2 account, and blob container.
+# Event Grid system topic and subscription are created by the ARM template (deployed in e2e.sh).
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "blobviaeg-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test (prereqs; function is deployed via ARM)
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Storage account must be StorageV2 (general purpose v2) for Event Grid system topic
+resource "azurerm_storage_account" "blob" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "logs" {
+  name                  = "logs"
+  storage_account_name   = azurerm_storage_account.blob.name
+  container_access_type = "private"
+}

--- a/BlobViaEventGrid/tests/terraform/main.tf
+++ b/BlobViaEventGrid/tests/terraform/main.tf
@@ -48,6 +48,6 @@ resource "azurerm_storage_account" "blob" {
 
 resource "azurerm_storage_container" "logs" {
   name                  = "logs"
-  storage_account_name   = azurerm_storage_account.blob.name
+  storage_account_name  = azurerm_storage_account.blob.name
   container_access_type = "private"
 }

--- a/BlobViaEventGrid/tests/terraform/outputs.tf
+++ b/BlobViaEventGrid/tests/terraform/outputs.tf
@@ -1,0 +1,30 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for ARM deployment and cleanup."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.blob.name
+  description = "Storage account name (for ARM parameters StorageAccountName / StorageAccountResourceGroup)."
+}
+
+output "storage_account_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the storage account (for ARM parameter StorageAccountResourceGroup)."
+}
+
+output "blob_container_name" {
+  value       = azurerm_storage_container.logs.name
+  description = "Blob container name for ARM parameter BlobContainerName and uploading test payload."
+}
+
+output "storage_account_connection_string" {
+  value       = azurerm_storage_account.blob.primary_connection_string
+  description = "Storage account connection string for uploading test blob."
+  sensitive   = true
+}

--- a/DiagnosticData/tests/.gitignore
+++ b/DiagnosticData/tests/.gitignore
@@ -1,0 +1,14 @@
+# Terraform
+terraform/.terraform/
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/.terraform.lock.hcl
+
+# E2E generated
+arm-params.json
+*.tmp
+.venv/
+
+# Local env (do not commit secrets)
+env.json
+testenv.json

--- a/DiagnosticData/tests/README.md
+++ b/DiagnosticData/tests/README.md
@@ -1,0 +1,62 @@
+# DiagnosticData E2E tests
+
+End-to-end test for the **Diagnostic Data** Azure Function using real diagnostic settings: a storage account streams its **Transaction** metric to an Event Hub, the function reads from the Event Hub and forwards to Coralogix.
+
+## Flow
+
+1. **Provision** – Terraform creates:
+   - Resource group, Event Hub namespace, Event Hub instance
+   - Two namespace auth rules (listen for the function, send for Azure diagnostic streaming)
+   - **Storage account** and blob container
+   - **Diagnostic setting** on the storage account: stream **Transaction** metric to the Event Hub
+2. **ARM deploy** – The [DiagnosticData ARM template](https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/DiagnosticData/ARM/DiagnosticData.json) deploys the function (same resource group).
+3. **Trigger data** – The script uploads **5–10 blobs** to the storage account. This generates storage transactions; Azure streams the Transaction metric to the Event Hub via the diagnostic setting; the function is triggered and forwards to Coralogix.
+4. **Verify** – After 2 minutes the script polls the Coralogix Get Data Usage API for `app=azure`, `subsystem=diagnosticdata-e2e` (retries every 30s, up to 15 times). Diagnostic data can take 1–2 minutes to appear.
+5. **Cleanup** – Resource group is deleted and Terraform state is cleared.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+- [Terraform](https://www.terraform.io/downloads) >= 1.7.4.
+- [jq](https://jqlang.github.io/jq/) for Step 4 verification.
+
+No Python or Event Hub SDK is required; the test uses `az storage blob upload` only.
+
+## Usage
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"   # or your Coralogix ingress
+export CORALOGIX_API_KEY="..."       # Send your data / Private key (for the function)
+export CORALOGIX_QUERY_API_KEY="..." # For Step 4 (Data Usage read); can equal CORALOGIX_API_KEY
+
+# Optional (defaults shown):
+# export CORALOGIX_APPLICATION=azure
+# export CORALOGIX_SUBSYSTEM=diagnosticdata-e2e
+# export NUM_BLOBS=8
+# export WAIT_INITIAL=120
+# export MAX_ATTEMPTS=15
+
+./e2e.sh
+```
+
+## Terraform
+
+The `terraform/` module creates:
+
+- **Resource group** and **Event Hub** namespace + hub (`insights-operational-logs`)
+- **Namespace authorization rules**: listen (for the function), send (for diagnostic streaming to Event Hub)
+- **Storage account** (StorageV2) and container `uploads`
+- **Diagnostic setting** on the storage account: **Transaction** metric → Event Hub (same as in the Azure portal: Metrics → Transaction, Destination → Stream to an event hub)
+
+Dependent resources are deployed via Terraform; the function is deployed via the ARM template.
+
+## Troubleshooting
+
+- **No logs in Coralogix** – Data is sent to `/azure/events/v1`; it may appear as logs (app/subsystem) or in another product area. Check the function’s Application Insights for `Sent messages. Response: 200` vs `4xx` to see if Coralogix accepted the request.
+- **Diagnostic data delay** – New diagnostic settings can take 1–2 minutes (or up to 90 in rare cases). Increase `WAIT_INITIAL` (e.g. 180) and `MAX_ATTEMPTS` if needed.
+- **Region** – Ensure `OTEL_ENDPOINT` matches your Coralogix region (e.g. `https://ingress.eu2.coralogix.com`).
+
+## References
+
+- [Diagnostic Data: Microsoft Azure Resource Manager (ARM)](https://coralogix.com/docs/integrations/azure/diagnostic-data-microsoft-azure-resource-manager/)
+- [terraform-coralogix-azure diagnosticdata module](https://github.com/coralogix/terraform-coralogix-azure/tree/master/modules/diagnosticdata)

--- a/DiagnosticData/tests/check_metrics.sh
+++ b/DiagnosticData/tests/check_metrics.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for DiagnosticData E2E app/subsystem (azure / diagnosticdata-e2e).
+# Set CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT for API host.
+
+: "${OTEL_ENDPOINT:=https://ingress.eu1.coralogix.com}"
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2"
+
+now_minus_60m() {
+  date -u -v-60M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+# Subsystem to filter: genericDimension key=subsystem_name, value=$SUBSYSTEM
+SUBSYSTEM="${SUBSYSTEM:-diagnosticdata-e2e}"
+
+fetch_data_usage() {
+  local from to
+  from=$(now_minus_60m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=1h" \
+    --data-urlencode "aggregate=AGGREGATE_BY_SUBSYSTEM" \
+    -H "Authorization: Bearer ${CORALOGIX_QUERY_API_KEY:-$CORALOGIX_API_KEY}" 2>/dev/null | head -1 | \
+    jq -r --arg sub "$SUBSYSTEM" '(.result.entries // []) | map(select(any(.dimensions[]?; .genericDimension? | select(.key == "subsystem_name" and .value == $sub)))) | map(.units) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=diagnosticdata-e2e)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_data_usage)
+  echo "Data units: $count"
+  if [[ -n "$count" ]] && awk -v n="$count" 'BEGIN{exit (n+0>0)?0:1}'; then
+    echo "Metrics verified in Coralogix (data units count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No data units received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No data units yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+#
+# E2E test for DiagnosticData Azure Function.
+#
+# Order of execution:
+#   1. Provision Azure resources with Terraform (RG, Event Hub, storage account with
+#      diagnostic setting that streams Transaction metric to Event Hub).
+#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   3. Upload 5–10 blobs to the storage account to generate transactions; diagnostic setting
+#      streams data to Event Hub; function reads and forwards to Coralogix.
+#   4. Wait 2 min, then poll Coralogix Data Usage API until subsystem units > 0 (retry every 30s, up to 15 times).
+#   5. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Environment variables (or export before running):
+#     - OTEL_ENDPOINT (required) – OTLP/ingress endpoint URL, e.g. https://ingress.coralogix.com
+#     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 (Data Usage API read permission).
+#     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
+#     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/DiagnosticData/ARM/DiagnosticData.json"
+
+# Number of blobs to upload to trigger storage transactions (diagnostic data streamed to Event Hub)
+NUM_BLOBS="${NUM_BLOBS:-8}"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+# For Step 4 verification
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
+
+# --- Step 1: Provision with Terraform ---
+log "Step 1: Provisioning Azure resources with Terraform (RG, Event Hub, storage account + diagnostic setting)..."
+cd "$TERRAFORM_DIR"
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
+EVENTHUB_NAME=$(terraform output -raw eventhub_name)
+EVENTHUB_RG=$(terraform output -raw eventhub_resource_group)
+EVENTHUB_SAS_POLICY_NAME=$(terraform output -raw eventhub_shared_access_policy_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+CONTAINER_NAME=$(terraform output -raw blob_container_name)
+
+log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, Storage container=$CONTAINER_NAME"
+
+# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+# DiagnosticData ARM expects CustomURL as the full Coralogix events URL (e.g. https://ingress.xxx/azure/events/v1)
+CORALOGIX_EVENTS_URL="${OTEL_ENDPOINT%/}/azure/events/v1"
+
+log "Step 2: Deploying ARM template from master (DiagnosticData function)..."
+PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
+build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
+{
+  echo '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#", "contentVersion": "1.0.0.0", "parameters": {'
+  echo '  "CoralogixRegion": { "value": "Custom" },'
+  echo "  $(build_param 'CustomURL' "$CORALOGIX_EVENTS_URL"),"
+  echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
+  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
+  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"),"
+  echo "  $(build_param 'EventhubResourceGroup' "$EVENTHUB_RG"),"
+  echo "  $(build_param 'EventhubNamespace' "$EVENTHUB_NAMESPACE"),"
+  echo "  $(build_param 'EventhubInstanceName' "$EVENTHUB_NAME"),"
+  echo "  $(build_param 'EventhubSharedAccessPolicyName' "$EVENTHUB_SAS_POLICY_NAME"),"
+  echo "  $(build_param 'FunctionAppServicePlanType' "${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}")"
+  echo '} }'
+} > "$PARAMS_FILE"
+
+az deployment group create \
+  --resource-group "$RG_NAME" \
+  --template-uri "$ARM_TEMPLATE_URI" \
+  --parameters "@${PARAMS_FILE}"
+
+rm -f "$PARAMS_FILE"
+log "ARM deployment completed."
+
+# --- Step 3: Upload blobs to generate storage transactions (diagnostic setting streams to Event Hub) ---
+log "Step 3: Uploading $NUM_BLOBS blobs to container $CONTAINER_NAME to trigger diagnostic data..."
+PAYLOAD_FILE="${SCRIPT_DIR}/.e2e-diagdata-payload.tmp"
+printf 'e2e diagnostic data test payload - %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$PAYLOAD_FILE"
+
+uploaded=0
+for i in $(seq 1 "$NUM_BLOBS"); do
+  blob_name="e2e-diagdata-$(date +%s)-$i.txt"
+  if az storage blob upload \
+    --connection-string "$STORAGE_CONNECTION_STRING" \
+    --container-name "$CONTAINER_NAME" \
+    --name "$blob_name" \
+    --file "$PAYLOAD_FILE" \
+    --type block \
+    --content-type "text/plain" \
+    --no-progress 2>/dev/null; then
+    uploaded=$((uploaded + 1))
+  fi
+done
+rm -f "$PAYLOAD_FILE"
+
+if [[ $uploaded -eq 0 ]]; then
+  err "Step 3: No blobs uploaded. Check storage connection string and container."
+  exit 1
+fi
+log "Uploaded $uploaded blobs. Diagnostic setting will stream Transaction metric to Event Hub (may take 1–2 min)."
+
+# --- Step 4: Verify data in Coralogix (poll Data Usage API for subsystem units) ---
+# Same approach as check_metrics.sh: sum .units for entries where dimensions contain
+# genericDimension key=subsystem_name, value=$CX_SUBSYS.
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST%%/*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_DATA_USAGE_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2"
+
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
+
+now_minus_60m() {
+  if date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-60M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_data_usage_units() {
+  local from to
+  from=$(now_minus_60m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_DATA_USAGE_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=1h" \
+    --data-urlencode "aggregate=AGGREGATE_BY_SUBSYSTEM" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" 2>/dev/null | head -1 | \
+    jq -r --arg sub "$CX_SUBSYS" '(.result.entries // []) | map(select(any(.dimensions[]?; .genericDimension? | select(.key == "subsystem_name" and .value == $sub)))) | map(.units) | add // 0'
+}
+
+# Diagnostic data can take 1–2 minutes (or more) to flow: storage → Event Hub → function → Coralogix
+WAIT_INITIAL="${WAIT_INITIAL:-120}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-15}"
+
+log "Step 4: Waiting ${WAIT_INITIAL}s for diagnostic data to flow, then verifying data in Coralogix (subsystem=$CX_SUBSYS, data usage units)..."
+sleep "$WAIT_INITIAL"
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  units=$(fetch_data_usage_units)
+  echo "Data units: $units"
+  if [[ -n "$units" ]] && awk -v n="$units" 'BEGIN{exit (n+0>0)?0:1}'; then
+    log "Step 4: Data verified in Coralogix (units=$units)."
+    break
+  fi
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 4: No data received in Coralogix after $MAX_ATTEMPTS attempts (last units=${units:-unknown})."
+    exit 1
+  fi
+  log "Step 4: No data yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 5: Clean up ---
+log "Step 5: Cleaning up resources..."
+trap - EXIT
+az group delete --name "$RG_NAME" --yes
+log "Waiting for resource group deletion..."
+while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# Clean Terraform state so next run can provision from scratch.
+cd "$TERRAFORM_DIR"
+while read -r state_key; do
+  [[ -z "$state_key" ]] && continue
+  terraform state rm "$state_key" 2>/dev/null || true
+done < <(terraform state list 2>/dev/null || true)
+log "E2E test finished."

--- a/DiagnosticData/tests/terraform/main.tf
+++ b/DiagnosticData/tests/terraform/main.tf
@@ -93,17 +93,17 @@ resource "azurerm_storage_account" "diag_source" {
 
 resource "azurerm_storage_container" "uploads" {
   name                  = "uploads"
-  storage_account_name   = azurerm_storage_account.diag_source.name
+  storage_account_name  = azurerm_storage_account.diag_source.name
   container_access_type = "private"
 }
 
 # Diagnostic setting on the storage account: stream Transaction metric to the Event Hub.
 # Uploading blobs generates transactions that Azure will stream to the hub.
 resource "azurerm_monitor_diagnostic_setting" "storage_to_eventhub" {
-  name                       = "diagdata-e2e-stream-to-eventhub"
-  target_resource_id         = azurerm_storage_account.diag_source.id
+  name                           = "diagdata-e2e-stream-to-eventhub"
+  target_resource_id             = azurerm_storage_account.diag_source.id
   eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.send.id
-  eventhub_name              = azurerm_eventhub.hub.name
+  eventhub_name                  = azurerm_eventhub.hub.name
 
   metric {
     category = "Transaction"

--- a/DiagnosticData/tests/terraform/main.tf
+++ b/DiagnosticData/tests/terraform/main.tf
@@ -1,0 +1,112 @@
+# Prerequisites for DiagnosticData E2E: resource group, Event Hub namespace, Event Hub instance,
+# namespace-level authorization rules (listen for function, send for diagnostic streaming),
+# a storage account with a diagnostic setting that streams Transaction metric to the Event Hub,
+# and a blob container for triggering storage transactions.
+# The function app is deployed via ARM in e2e.sh.
+#
+# Flow: Upload blobs → storage transactions → Diagnostic Setting streams to Event Hub →
+# DiagnosticData function reads from Event Hub → Coralogix.
+# See: https://github.com/coralogix/terraform-coralogix-azure/tree/master/modules/diagnosticdata
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "cx-diagdata-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test (prereqs; function is deployed via ARM)
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Event Hub namespace (Standard for multiple hubs if needed)
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+# Event Hub instance (Diagnostic Settings stream to a hub like this)
+resource "azurerm_eventhub" "hub" {
+  name                = "insights-operational-logs"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+# Namespace-level authorization rule: listen (used by the function via ARM EventhubSharedAccessPolicyName)
+resource "azurerm_eventhub_namespace_authorization_rule" "listen" {
+  name                = "diagnosticdata-e2e-listen"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = true
+  send                = false
+  manage              = false
+}
+
+# Namespace-level authorization rule: send (used by Azure to stream diagnostic data to Event Hub)
+resource "azurerm_eventhub_namespace_authorization_rule" "send" {
+  name                = "diagnosticdata-e2e-send"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = false
+  send                = true
+  manage              = false
+}
+
+# Storage account used to generate diagnostic data (transactions) that stream to Event Hub
+resource "azurerm_storage_account" "diag_source" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_container" "uploads" {
+  name                  = "uploads"
+  storage_account_name   = azurerm_storage_account.diag_source.name
+  container_access_type = "private"
+}
+
+# Diagnostic setting on the storage account: stream Transaction metric to the Event Hub.
+# Uploading blobs generates transactions that Azure will stream to the hub.
+resource "azurerm_monitor_diagnostic_setting" "storage_to_eventhub" {
+  name                       = "diagdata-e2e-stream-to-eventhub"
+  target_resource_id         = azurerm_storage_account.diag_source.id
+  eventhub_authorization_rule_id = azurerm_eventhub_namespace_authorization_rule.send.id
+  eventhub_name              = azurerm_eventhub.hub.name
+
+  metric {
+    category = "Transaction"
+    enabled  = true
+  }
+}

--- a/DiagnosticData/tests/terraform/outputs.tf
+++ b/DiagnosticData/tests/terraform/outputs.tf
@@ -1,0 +1,45 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for ARM deployment and cleanup."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "eventhub_namespace" {
+  value       = azurerm_eventhub_namespace.ns.name
+  description = "Event Hub namespace (for ARM parameter EventhubNamespace)."
+}
+
+output "eventhub_name" {
+  value       = azurerm_eventhub.hub.name
+  description = "Event Hub instance name (for ARM parameter EventhubInstanceName)."
+}
+
+output "eventhub_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the Event Hub (for ARM parameter EventhubResourceGroup)."
+}
+
+output "eventhub_shared_access_policy_name" {
+  value       = azurerm_eventhub_namespace_authorization_rule.listen.name
+  description = "Namespace authorization rule name for listen (for ARM parameter EventhubSharedAccessPolicyName)."
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.diag_source.name
+  description = "Storage account name (used to generate diagnostic data via blob uploads)."
+}
+
+output "storage_account_connection_string" {
+  value       = azurerm_storage_account.diag_source.primary_connection_string
+  description = "Storage account connection string for uploading test blobs (triggers transactions → Event Hub)."
+  sensitive   = true
+}
+
+output "blob_container_name" {
+  value       = azurerm_storage_container.uploads.name
+  description = "Blob container name for uploads (e2e uploads files here to trigger diagnostic data)."
+}

--- a/EventHub/tests/.gitignore
+++ b/EventHub/tests/.gitignore
@@ -1,0 +1,15 @@
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/*.tfvars
+!terraform/*.tfvars.example
+
+# Python venv (for azure-eventhub when running e2e)
+.venv/
+venv/
+
+# E2E generated
+arm-params.json
+.e2e-test-payload.tmp

--- a/EventHub/tests/README.md
+++ b/EventHub/tests/README.md
@@ -1,0 +1,78 @@
+# EventHub E2E tests
+
+End-to-end test for the EventHub Azure Function: provision Event Hub resources with Terraform, deploy the function via ARM (latest master), send test events to the Event Hub to trigger the function, verify logs in Coralogix, then clean up.
+
+## Flow
+
+1. **Provision** – Terraform creates resource group, Event Hub namespace, Event Hub instance, consumer group, and two namespace-level authorization rules (listen for the function, send for the test script).
+2. **ARM deploy** – The [EventHub ARM template](https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/EventHub/ARM/EventHubV2.json) is deployed with Azure CLI. It creates the function app (and its storage, plan, App Insights) in the same resource group; parameters are set from the resources created in step 1.
+3. **Test payload** – A small script sends one or more test events to the Event Hub; the function is triggered and forwards logs to Coralogix (OTLP).
+4. **Verify** – After 30s the script polls the Coralogix Get Logs Count API (last 10 min, 10m resolution) for `app=azure`, `subsystem=eventhub-e2e`. If count is 0, it retries every 30s up to 10 times; if count > 0, it proceeds. Requires an API key with Data Usage read permission.
+5. **Cleanup** – Resource group is deleted and Terraform state is cleared.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+- [Terraform](https://www.terraform.io/downloads) >= 1.7.4.
+- [jq](https://jqlang.github.io/jq/) (for Step 4 verification).
+- Python 3 with [azure-eventhub](https://pypi.org/project/azure-eventhub/) for sending events. On macOS (Homebrew Python) use a virtual environment to avoid "externally-managed-environment":
+  ```bash
+  cd EventHub/tests
+  python3 -m venv .venv
+  source .venv/bin/activate
+  pip install -r requirements.txt
+  ```
+  Then run `./e2e.sh` with the venv still activated.
+
+**Azure login** – The script logs in automatically if you set:
+
+- **Service principal** (CI/non-interactive): `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`
+- **Managed identity** (e.g. running inside Azure): `AZURE_USE_MANAGED_IDENTITY=1`
+
+Otherwise run `az login` once before `./e2e.sh`.
+
+## Usage
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"   # or your OTLP endpoint
+export CORALOGIX_API_KEY="..."       # Send your data / Private key (for the function)
+export CORALOGIX_QUERY_API_KEY="..." # For Step 4 (Data Usage read); can equal CORALOGIX_API_KEY
+
+# Optional (defaults shown):
+# export CORALOGIX_APPLICATION=azure
+# export CORALOGIX_SUBSYSTEM=eventhub-e2e
+
+./e2e.sh
+```
+
+## Terraform
+
+The `terraform/` directory contains a root module that:
+
+- Creates a resource group and an **Event Hub namespace** (Standard SKU).
+- Creates an **Event Hub** instance and a **consumer group** for the Coralogix function.
+- Creates two **namespace-level authorization rules**:
+  - `coralogix-e2e-listen` – listen only (used by the ARM-deployed function).
+  - `e2e-send` – send only (used by the e2e script to send test events).
+
+Dependent resources are deployed via Terraform; the function app itself is deployed via the ARM template (same pattern as [terraform-coralogix-azure EventHub module](https://github.com/coralogix/terraform-coralogix-azure/tree/master/modules/eventhub)).
+
+## Verifying logs in Coralogix (Get Logs Count API)
+
+To check that logs arrived for the e2e app/subsystem, use the [Get Logs Count](https://docs.coralogix.com/api-reference/latest/data-usage-service/get-logs-count) API:
+
+```bash
+FROM_DATE=$(date -u -v-1H +%Y-%m-%dT%H:%M:%S.000Z)
+TO_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+curl -s -G "https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count" \
+  --data-urlencode "date_range.fromDate=$FROM_DATE" \
+  --data-urlencode "date_range.toDate=$TO_DATE" \
+  --data-urlencode "resolution=1h" \
+  --data-urlencode "filters.application=azure" \
+  --data-urlencode "filters.subsystem=eventhub-e2e" \
+  --data-urlencode "subsystem_aggregation=true" \
+  -H "Authorization: Bearer $CX_API_KEY"
+```
+
+Use the same region as your OTEL endpoint (e.g. `api.eu2.coralogix.com` for EU2). The API key needs Data Usage read permission.

--- a/EventHub/tests/check_logs.sh
+++ b/EventHub/tests/check_logs.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for EventHub E2E app/subsystem (azure / eventhub-e2e).
+# Set CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally OTEL_ENDPOINT for API host.
+
+: "${OTEL_ENDPOINT:=https://ingress.eu1.coralogix.com}"
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=eventhub-e2e" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer ${CORALOGIX_QUERY_API_KEY:-$CORALOGIX_API_KEY}" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Verifying logs in Coralogix (app=azure, subsystem=eventhub-e2e)..."
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# E2E test for EventHub Azure Function.
+#
+# Order of execution:
+#   1. Provision Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules).
+#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   3. Send test events to the Event Hub to trigger the function.
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   5. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Python 3 with azure-eventhub (pip install azure-eventhub) for sending events.
+#   - Environment variables (or export before running):
+#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.eu1.coralogix.com
+#     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – for the function and for Step 4 verification (Data Usage read).
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/EventHub/ARM/EventHubV2.json"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+# For Step 4 verification
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+# cleanup_after_failure() {
+#   log "Cleaning up after failure..."
+#   if [[ -n "${RG_NAME:-}" ]]; then
+#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+#   fi
+# }
+# trap cleanup_after_failure EXIT
+
+# --- Step 1: Provision with Terraform ---
+log "Step 1: Provisioning Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules)..."
+cd "$TERRAFORM_DIR"
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
+EVENTHUB_NAME=$(terraform output -raw eventhub_name)
+EVENTHUB_RG=$(terraform output -raw eventhub_resource_group)
+EVENTHUB_CONSUMER_GROUP=$(terraform output -raw eventhub_consumer_group_name)
+EVENTHUB_SAS_KEY_NAME=$(terraform output -raw eventhub_shared_access_key_name)
+EVENTHUB_SEND_CONNECTION_STRING=$(terraform output -raw eventhub_send_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, ConsumerGroup=$EVENTHUB_CONSUMER_GROUP"
+
+# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+# EventHubV2 expects CustomURL as host:port (e.g. ingress.eu1.coralogix.com:443)
+CUSTOM_URL="${OTEL_ENDPOINT#*://}"
+CUSTOM_URL="${CUSTOM_URL%%/*}"
+if [[ "$CUSTOM_URL" != *:* ]]; then
+  CUSTOM_URL="${CUSTOM_URL}:443"
+fi
+
+log "Step 2: Deploying ARM template from master (EventHub function)..."
+PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
+build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
+{
+  echo '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#", "contentVersion": "1.0.0.0", "parameters": {'
+  echo '  "CoralogixRegion": { "value": "Custom" },'
+  echo "  $(build_param 'CustomURL' "$CUSTOM_URL"),"
+  echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
+  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
+  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"),"
+  echo "  $(build_param 'EventhubResourceGroup' "$EVENTHUB_RG"),"
+  echo "  $(build_param 'EventhubNamespace' "$EVENTHUB_NAMESPACE"),"
+  echo "  $(build_param 'EventhubInstanceName' "$EVENTHUB_NAME"),"
+  echo "  $(build_param 'EventhubSharedAccessKeyName' "$EVENTHUB_SAS_KEY_NAME"),"
+  echo "  $(build_param 'EventhubConsumerGroup' "$EVENTHUB_CONSUMER_GROUP"),"
+  echo "  $(build_param 'FunctionAppServicePlanType' "${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}"),"
+  echo '  "CoralogixApplicationSelector": { "value": "" },'
+  echo '  "CoralogixSubsystemSelector": { "value": "" },'
+  echo '  "NewlinePattern": { "value": "(?:\\\\r\\\\n|\\\\r|\\\\n)" },'
+  echo '  "BlockingPattern": { "value": "" }'
+  echo '} }'
+} > "$PARAMS_FILE"
+
+az deployment group create \
+  --resource-group "$RG_NAME" \
+  --template-uri "$ARM_TEMPLATE_URI" \
+  --parameters "@${PARAMS_FILE}"
+
+rm -f "$PARAMS_FILE"
+log "ARM deployment completed."
+
+# --- Step 3: Send test events to Event Hub to trigger the function ---
+log "Step 3: Sending test event (JSON payload) to Event Hub..."
+# Short NYC taxi-style JSON payload (same structure that works with the function)
+TEST_MESSAGE='{"vendorID":"5","tpepPickupDateTime":1528119858000,"tpepDropoffDateTime":1528121148000,"passengerCount":2,"tripDistance":4.62,"puLocationId":"186","doLocationId":"230","rateCodeId":1,"storeAndFwdFlag":"N","paymentType":2,"fareAmount":13.5,"extra":0,"mtaTax":0.5,"improvementSurcharge":"0.3","tipAmount":2.86,"tollsAmount":0,"totalAmount":17.16}'
+if ! python3 "${SCRIPT_DIR}/send_event.py" "$EVENTHUB_SEND_CONNECTION_STRING" "$TEST_MESSAGE"; then
+  err "Failed to send event to Event Hub. Install: pip install azure-eventhub"
+  exit 1
+fi
+log "Sent test event to Event Hub: $EVENTHUB_NAMESPACE/$EVENTHUB_NAME"
+
+# --- Step 4: Verify logs landed in Coralogix (poll Get Logs Count API) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST%%/*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=$CX_APP" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 4: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 5: Clean up ---
+# log "Step 5: Cleaning up resources..."
+# trap - EXIT
+# az group delete --name "$RG_NAME" --yes
+# log "Waiting for resource group deletion..."
+# while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# # Clean Terraform state so next run can provision from scratch.
+# cd "$TERRAFORM_DIR"
+# while read -r state_key; do
+#   [[ -z "$state_key" ]] && continue
+#   terraform state rm "$state_key" 2>/dev/null || true
+# done < <(terraform state list 2>/dev/null || true)
+log "E2E test finished."

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -39,13 +39,13 @@ CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
-# cleanup_after_failure() {
-#   log "Cleaning up after failure..."
-#   if [[ -n "${RG_NAME:-}" ]]; then
-#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
-#   fi
-# }
-# trap cleanup_after_failure EXIT
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
 log "Step 1: Provisioning Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules)..."
@@ -163,15 +163,15 @@ while true; do
 done
 
 # --- Step 5: Clean up ---
-# log "Step 5: Cleaning up resources..."
-# trap - EXIT
-# az group delete --name "$RG_NAME" --yes
-# log "Waiting for resource group deletion..."
-# while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
-# # Clean Terraform state so next run can provision from scratch.
-# cd "$TERRAFORM_DIR"
-# while read -r state_key; do
-#   [[ -z "$state_key" ]] && continue
-#   terraform state rm "$state_key" 2>/dev/null || true
-# done < <(terraform state list 2>/dev/null || true)
+log "Step 5: Cleaning up resources..."
+trap - EXIT
+az group delete --name "$RG_NAME" --yes
+log "Waiting for resource group deletion..."
+while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# Clean Terraform state so next run can provision from scratch.
+cd "$TERRAFORM_DIR"
+while read -r state_key; do
+  [[ -z "$state_key" ]] && continue
+  terraform state rm "$state_key" 2>/dev/null || true
+done < <(terraform state list 2>/dev/null || true)
 log "E2E test finished."

--- a/EventHub/tests/requirements.txt
+++ b/EventHub/tests/requirements.txt
@@ -1,0 +1,2 @@
+# For send_event.py (E2E test)
+azure-eventhub>=5.0.0

--- a/EventHub/tests/send_event.py
+++ b/EventHub/tests/send_event.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+Send a single event to an Azure Event Hub. Used by the E2E test to trigger the function.
+Requires: pip install azure-eventhub
+Usage: send_event.py <connection_string> <message_body>
+"""
+import sys
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: send_event.py <connection_string> <message_body>", file=sys.stderr)
+        sys.exit(1)
+    conn_str = sys.argv[1]
+    body = sys.argv[2]
+
+    try:
+        from azure.eventhub import EventHubProducerClient, EventData
+    except ImportError:
+        print("Install azure-eventhub: pip install azure-eventhub", file=sys.stderr)
+        sys.exit(1)
+
+    client = EventHubProducerClient.from_connection_string(conn_str)
+    try:
+        batch = client.create_batch()
+        batch.add(EventData(body))
+        client.send_batch(batch)
+    finally:
+        client.close()
+
+if __name__ == "__main__":
+    main()

--- a/EventHub/tests/terraform/main.tf
+++ b/EventHub/tests/terraform/main.tf
@@ -1,0 +1,83 @@
+# Prerequisites for EventHub E2E: resource group, Event Hub namespace, Event Hub instance,
+# consumer group, and authorization rules (listen for the function, send for the test script).
+# The function app is deployed via ARM in e2e.sh.
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "cx-eventhub-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test (prereqs; function is deployed via ARM)
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Event Hub namespace
+resource "azurerm_eventhub_namespace" "ns" {
+  name                = "${local.name_prefix}-ehns-${random_string.suffix.result}"
+  location            = azurerm_resource_group.e2e.location
+  resource_group_name = azurerm_resource_group.e2e.name
+  sku                 = "Standard"
+  capacity            = 1
+}
+
+# Event Hub instance (the hub that receives events; function is triggered from here)
+resource "azurerm_eventhub" "hub" {
+  name                = "logs"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  partition_count     = 2
+  message_retention   = 1
+}
+
+# Consumer group for the ARM-deployed EventHub function
+resource "azurerm_eventhub_consumer_group" "coralogix" {
+  name                = "coralogix-e2e"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  eventhub_name       = azurerm_eventhub.hub.name
+  resource_group_name = azurerm_resource_group.e2e.name
+}
+
+# Namespace-level authorization rule: listen only (used by the function via ARM)
+resource "azurerm_eventhub_namespace_authorization_rule" "listen" {
+  name                = "coralogix-e2e-listen"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = true
+  send                = false
+  manage              = false
+}
+
+# Namespace-level authorization rule: send only (used by e2e script to send test events)
+resource "azurerm_eventhub_namespace_authorization_rule" "send" {
+  name                = "e2e-send"
+  namespace_name      = azurerm_eventhub_namespace.ns.name
+  resource_group_name = azurerm_resource_group.e2e.name
+  listen              = false
+  send                = true
+  manage              = false
+}

--- a/EventHub/tests/terraform/outputs.tf
+++ b/EventHub/tests/terraform/outputs.tf
@@ -1,0 +1,41 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for ARM deployment and cleanup."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "eventhub_namespace" {
+  value       = azurerm_eventhub_namespace.ns.name
+  description = "Event Hub namespace (for ARM parameter EventhubNamespace)."
+}
+
+output "eventhub_name" {
+  value       = azurerm_eventhub.hub.name
+  description = "Event Hub instance name (for ARM parameter EventhubInstanceName)."
+}
+
+output "eventhub_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the Event Hub (for ARM parameter EventhubResourceGroup)."
+}
+
+output "eventhub_consumer_group_name" {
+  value       = azurerm_eventhub_consumer_group.coralogix.name
+  description = "Event Hub consumer group name (for ARM parameter EventhubConsumerGroup)."
+}
+
+output "eventhub_shared_access_key_name" {
+  value       = azurerm_eventhub_namespace_authorization_rule.listen.name
+  description = "Event Hub namespace authorization rule name for listen (for ARM parameter EventhubSharedAccessKeyName)."
+}
+
+# Connection string for sending test events (namespace send rule + EntityPath for the hub)
+output "eventhub_send_connection_string" {
+  value       = "${azurerm_eventhub_namespace_authorization_rule.send.primary_connection_string};EntityPath=${azurerm_eventhub.hub.name}"
+  description = "Connection string for sending events to the Event Hub (used by e2e script)."
+  sensitive   = true
+}

--- a/StorageQueue/ARM/StorageQueue.json
+++ b/StorageQueue/ARM/StorageQueue.json
@@ -189,8 +189,8 @@
               "value": "[parameters('CoralogixSubsystem')]"
             },
             {
-              "Name": "CORALOGIX_URL",
-              "Value": "[variables('CoralogixURL')]"
+              "name": "CORALOGIX_URL",
+              "value": "[variables('CoralogixURL')]"
             },
             {
               "name": "STORAGE_QUEUE_CONNECT_STRING",

--- a/StorageQueue/CHANGELOG.md
+++ b/StorageQueue/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 2.0.3 / 19 Feb 2026
+[Bug] Fix the package type from `module` to `commonjs`
+[Bug] Update ARM template (parameter case matching)
+
 ### 2.0.2 / 25 Apr 2025
 [Update] Bump Node.js runtime to version 20
 

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "type": "commonjs",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -2,7 +2,7 @@
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
   "version": "2.0.1",
-  "type": "module",
+  "type": "commonjs",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/StorageQueue/tests/.gitignore
+++ b/StorageQueue/tests/.gitignore
@@ -1,0 +1,11 @@
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/*.tfvars
+!terraform/*.tfvars.example
+
+# E2E generated
+arm-params.json
+.e2e-test-payload.tmp

--- a/StorageQueue/tests/README.md
+++ b/StorageQueue/tests/README.md
@@ -1,0 +1,69 @@
+# StorageQueue E2E tests
+
+End-to-end test for the StorageQueue Azure Function: provision prereqs with Terraform (resource group, StorageV2 account, queue), deploy the function via ARM (latest master), trigger with a JSON message in the queue, then clean up.
+
+## Flow
+
+1. **Provision** – Terraform creates resource group, StorageV2 storage account, and a storage queue. The [terraform-coralogix-azure StorageQueue module](https://github.com/coralogix/terraform-coralogix-azure/tree/master/modules/storagequeue) expects these resources to exist; the ARM template deploys the function and uses the queue’s storage account and queue name.
+2. **ARM deploy** – The [StorageQueue ARM template](https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/StorageQueue/ARM/StorageQueue.json) is deployed with Azure CLI. It creates the function app (and its own function storage account), configured with the queue connection string and queue name. The function is triggered by messages in the storage queue.
+3. **Test payload** – A JSON message is put into the queue (base64-encoded, as required by Azure Storage Queue). The function processes it and sends the log to Coralogix. Only JSON-formatted queue messages are processed (see [Queue Storage ARM docs](https://coralogix.com/docs/integrations/azure/queue-storage-microsoft-azure-resource-manager/)).
+4. **Verify** – After 30s the script polls the Coralogix Get Logs Count API (last 10 min, 10m resolution) for `app=azure`, `subsystem=storage-queue-e2e`. If count is 0, it retries every 30s up to 10 times; if count > 0, it proceeds. Requires an API key with Data Usage read permission.
+5. **Cleanup** – Resource group is deleted and Terraform state is cleared.
+
+## Prerequisites
+
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) installed.
+- [Terraform](https://www.terraform.io/downloads) >= 1.7.4.
+- [jq](https://jqlang.github.io/jq/) (for Step 4 verification).
+
+**Azure login** – The script uses Azure CLI; set service principal env vars for CI or run `az login` before `./e2e.sh`.
+
+## Usage
+
+```bash
+export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"   # Coralogix ingress base URL
+export CORALOGIX_API_KEY="..."       # Send your data / Private key (for the function)
+export CORALOGIX_QUERY_API_KEY="..." # For Step 4 (Data Usage read); can equal CORALOGIX_API_KEY
+
+# Optional (defaults shown):
+# export CORALOGIX_APPLICATION=azure
+# export CORALOGIX_SUBSYSTEM=storage-queue-e2e
+
+./e2e.sh
+```
+
+## Terraform
+
+The `terraform/` directory creates:
+
+- A resource group for the e2e test (ARM deploys the function into this RG).
+- A **StorageV2** (general purpose v2) storage account (required by Coralogix Queue Storage integration).
+- A storage queue. The ARM template configures the function with this queue’s storage account and queue name; the function is triggered when messages are added to the queue.
+
+The ARM template creates its own function app storage account and does not use a separate “function” storage account from Terraform.
+
+## Verifying logs in Coralogix (Get Logs Count API)
+
+To check that logs arrived for the e2e app/subsystem, use the [Get Logs Count](https://docs.coralogix.com/api-reference/latest/data-usage-service/get-logs-count) API with `filters.application=azure` and `filters.subsystem=storage-queue-e2e` (or your `CORALOGIX_SUBSYSTEM`). Example:
+
+```bash
+FROM_DATE=$(date -u -v-1H +%Y-%m-%dT%H:%M:%S.000Z)
+TO_DATE=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+
+curl -s -G "https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count" \
+  --data-urlencode "date_range.fromDate=$FROM_DATE" \
+  --data-urlencode "date_range.toDate=$TO_DATE" \
+  --data-urlencode "resolution=1h" \
+  --data-urlencode "filters.application=azure" \
+  --data-urlencode "filters.subsystem=storage-queue-e2e" \
+  --data-urlencode "subsystem_aggregation=true" \
+  -H "Authorization: Bearer $CX_API_KEY"
+```
+
+Use the same region as your Coralogix endpoint (e.g. `api.eu2.coralogix.com` for EU2). The API key needs Data Usage read permission.
+
+## Difference from BlobViaEventGrid / BlobToOtel E2E
+
+- **StorageQueue** is triggered by **Storage Queue** messages. Terraform provisions the resource group, the queue’s storage account, and the queue; the ARM template deploys the function with a queue trigger. The test sends a JSON message (base64-encoded) into the queue.
+- **BlobViaEventGrid** is triggered by Event Grid (blob created → Event Grid → function). Terraform provisions storage + container; ARM creates the Event Grid subscription.
+- **BlobToOtel** is triggered via Event Hub (blob → Event Grid → Event Hub → function). Terraform provisions storage, Event Hub, and consumer group; ARM deploys the function with an Event Hub trigger.

--- a/StorageQueue/tests/check_logs.sh
+++ b/StorageQueue/tests/check_logs.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Poll Coralogix Get Logs Count API for app=azure, subsystem=storage-queue-e2e (same as e2e.sh verification).
+# Requires: CORALOGIX_QUERY_API_KEY (or CORALOGIX_API_KEY) and optionally CX_LOGS_COUNT_URL or OTEL_ENDPOINT to derive API host.
+
+if [[ -n "${CX_LOGS_COUNT_URL:-}" ]]; then
+  :
+elif [[ -n "${OTEL_ENDPOINT:-}" ]]; then
+  CX_API_HOST="${OTEL_ENDPOINT#*://}"
+  CX_API_HOST="${CX_API_HOST%%:*}"
+  CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+  CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+else
+  CX_LOGS_COUNT_URL="https://api.eu2.coralogix.com/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+fi
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_SUBSYSTEM="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYSTEM" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+echo "Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYSTEM)..."
+# sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    echo "Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    echo "No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  echo "No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# E2E test for StorageQueue Azure Function.
+#
+# Order of execution:
+#   1. Provision Azure resources with Terraform (resource group, StorageV2 account, queue).
+#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   3. Send a test payload (put a JSON message into the storage queue to trigger the function).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   5. Clean up all resources.
+#
+# Prerequisites:
+#   - Azure CLI installed and logged in (az login).
+#   - Terraform >= 1.7.4.
+#   - jq (for parsing Coralogix API response).
+#   - Environment variables (or export before running):
+#     - OTEL_ENDPOINT (required) – Coralogix ingress base URL, e.g. https://ingress.coralogix.com
+#     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
+#     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
+#     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#
+# Usage:
+#   export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"
+#   export CORALOGIX_API_KEY="your-send-your-data-key"
+#   export CORALOGIX_QUERY_API_KEY="your-query-key"
+#   ./e2e.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
+ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/StorageQueue/ARM/StorageQueue.json"
+
+# Required
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
+
+# For Step 4 verification
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+
+# Coralogix logs API URL (ARM CustomURL expects full URL, e.g. https://ingress.XXX/api/v1/logs)
+if [[ "$OTEL_ENDPOINT" == *"/api/v1/logs" ]]; then
+  CORALOGIX_LOGS_URL="$OTEL_ENDPOINT"
+else
+  CORALOGIX_LOGS_URL="${OTEL_ENDPOINT%/}/api/v1/logs"
+fi
+
+log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
+
+# cleanup_after_failure() {
+#   log "Cleaning up after failure..."
+#   if [[ -n "${RG_NAME:-}" ]]; then
+#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+#   fi
+# }
+# trap cleanup_after_failure EXIT
+
+# --- Step 1: Provision with Terraform ---
+log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."
+cd "$TERRAFORM_DIR"
+terraform init -input=false
+terraform apply -input=false -auto-approve
+
+RG_NAME=$(terraform output -raw resource_group_name)
+STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
+STORAGE_RG=$(terraform output -raw storage_account_resource_group)
+STORAGE_QUEUE_NAME=$(terraform output -raw storage_queue_name)
+STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_string)
+
+log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Queue=$STORAGE_QUEUE_NAME"
+
+# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+log "Step 2: Deploying ARM template from master (function + queue trigger)..."
+PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
+# Build parameters JSON; escape quotes in values.
+build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
+{
+  echo '{ "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#", "contentVersion": "1.0.0.0", "parameters": {'
+  echo '  "CoralogixRegion": { "value": "Custom" },'
+  echo "  $(build_param 'CustomURL' "$CORALOGIX_LOGS_URL"),"
+  echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
+  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
+  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"),"
+  echo "  $(build_param 'StorageAccountName' "$STORAGE_ACCOUNT"),"
+  echo "  $(build_param 'StorageAccountResourceGroup' "$STORAGE_RG"),"
+  echo "  $(build_param 'StorageQueueName' "$STORAGE_QUEUE_NAME"),"
+  echo "  $(build_param 'FunctionAppServicePlanType' "${FUNCTION_APP_SERVICE_PLAN_TYPE:-Consumption}")"
+  echo '} }'
+} > "$PARAMS_FILE"
+
+az deployment group create \
+  --resource-group "$RG_NAME" \
+  --template-uri "$ARM_TEMPLATE_URI" \
+  --parameters "@${PARAMS_FILE}"
+
+rm -f "$PARAMS_FILE"
+log "ARM deployment completed."
+
+# --- Step 3: Send test payload (put JSON message into queue to trigger function) ---
+# Storage Queue messages are base64-encoded. Function expects JSON-formatted queue messages.
+log "Step 3: Putting JSON test message into storage queue to trigger the function..."
+TEST_MSG="{\"e2e\":\"storage-queue\",\"source\":\"e2e-test\",\"ts\":$(date +%s)}"
+MSG_B64=$(echo -n "$TEST_MSG" | base64)
+az storage message put \
+  --queue-name "$STORAGE_QUEUE_NAME" \
+  --content "$MSG_B64" \
+  --connection-string "$STORAGE_CONNECTION_STRING" \
+  --output none
+
+log "Put test message into queue: $STORAGE_QUEUE_NAME"
+
+# --- Step 4: Verify logs landed in Coralogix (poll Get Logs Count API) ---
+CX_API_HOST="${OTEL_ENDPOINT#*://}"
+CX_API_HOST="${CX_API_HOST%%:*}"
+CX_API_HOST="${CX_API_HOST/#ingress./api.}"
+CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
+
+# Subsystem used in ARM parameters (must match build_param above)
+CX_SUBSYSTEM="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
+
+now_minus_10m() {
+  if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
+    return
+  fi
+  date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
+}
+
+fetch_logs_count() {
+  local from to
+  from=$(now_minus_10m)
+  to=$(date -u +%Y-%m-%dT%H:%M:%S.000Z)
+  curl -s -G "$CX_LOGS_COUNT_URL" \
+    --data-urlencode "date_range.fromDate=$from" \
+    --data-urlencode "date_range.toDate=$to" \
+    --data-urlencode "resolution=10m" \
+    --data-urlencode "filters.application=azure" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYSTEM" \
+    --data-urlencode "subsystem_aggregation=true" \
+    -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
+}
+
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYSTEM)..."
+sleep 30
+
+attempt=0
+while true; do
+  attempt=$((attempt + 1))
+  count=$(fetch_logs_count)
+  if [[ -n "$count" && "$count" -gt 0 ]]; then
+    log "Step 4: Logs verified in Coralogix (count=$count)."
+    break
+  fi
+  if [[ $attempt -ge 10 ]]; then
+    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+    exit 1
+  fi
+  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  sleep 30
+done
+
+# --- Step 5: Clean up ---
+# log "Step 5: Cleaning up resources..."
+# trap - EXIT
+# az group delete --name "$RG_NAME" --yes
+# log "Waiting for resource group deletion..."
+# while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# # Clean Terraform state so next run can provision from scratch.
+# cd "$TERRAFORM_DIR"
+# while read -r state_key; do
+#   [[ -z "$state_key" ]] && continue
+#   terraform state rm "$state_key" 2>/dev/null || true
+# done < <(terraform state list 2>/dev/null || true)
+log "E2E test finished."

--- a/StorageQueue/tests/terraform/main.tf
+++ b/StorageQueue/tests/terraform/main.tf
@@ -49,5 +49,5 @@ resource "azurerm_storage_account" "queue" {
 
 resource "azurerm_storage_queue" "logs" {
   name                 = "coralogix-logs"
-  storage_account_name  = azurerm_storage_account.queue.name
+  storage_account_name = azurerm_storage_account.queue.name
 }

--- a/StorageQueue/tests/terraform/main.tf
+++ b/StorageQueue/tests/terraform/main.tf
@@ -1,0 +1,53 @@
+# Prerequisites for StorageQueue E2E: resource group, StorageV2 account, and storage queue.
+# The function app is deployed via ARM (e2e.sh). ARM creates its own function storage account
+# and uses the queue storage account + queue name from these outputs.
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.93"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.4"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  name_prefix = "storagequeue-e2e"
+  location    = "eastus"
+}
+
+# Single resource group for the e2e test (prereqs; function is deployed via ARM into this RG)
+resource "azurerm_resource_group" "e2e" {
+  name     = "${local.name_prefix}-rg"
+  location = local.location
+}
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+# Storage account containing the queue. Must be StorageV2 (general purpose v2) per Coralogix docs.
+resource "azurerm_storage_account" "queue" {
+  name                     = lower(replace("${local.name_prefix}st${random_string.suffix.result}", "-", ""))
+  resource_group_name      = azurerm_resource_group.e2e.name
+  location                 = azurerm_resource_group.e2e.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
+  account_kind             = "StorageV2"
+}
+
+resource "azurerm_storage_queue" "logs" {
+  name                 = "coralogix-logs"
+  storage_account_name  = azurerm_storage_account.queue.name
+}

--- a/StorageQueue/tests/terraform/outputs.tf
+++ b/StorageQueue/tests/terraform/outputs.tf
@@ -1,0 +1,30 @@
+output "resource_group_name" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group name for ARM deployment and cleanup."
+}
+
+output "resource_group_location" {
+  value       = azurerm_resource_group.e2e.location
+  description = "Resource group location."
+}
+
+output "storage_account_name" {
+  value       = azurerm_storage_account.queue.name
+  description = "Storage account name containing the queue (for ARM parameters StorageAccountName / StorageAccountResourceGroup)."
+}
+
+output "storage_account_resource_group" {
+  value       = azurerm_resource_group.e2e.name
+  description = "Resource group of the storage account (for ARM parameter StorageAccountResourceGroup)."
+}
+
+output "storage_queue_name" {
+  value       = azurerm_storage_queue.logs.name
+  description = "Storage queue name (for ARM parameter StorageQueueName and sending test messages)."
+}
+
+output "storage_account_connection_string" {
+  value       = azurerm_storage_account.queue.primary_connection_string
+  description = "Storage account connection string for putting test messages into the queue."
+  sensitive   = true
+}


### PR DESCRIPTION
# Description

Fixes CDS-2468 by implementing E2E tests for all Azure functions.

Stage 1 prepares tests themselves, makes sure they run properly locally and creates GH Workflow, merging it to master is required for any further testing.

Stage 2 will correct the GH Workflow, thus creating a CI pipeline for testing.

All tests work the same way with some function-related adjustments.

1. Create function-dependent resources via Terraform.
2. Create the function via ARM template.
3. Put test data to the function-dependent resource.
4. Query Coralogix DataUsage API to check if data appeared in the platform
5. Signal success/failure and destroy all resources.

Requires AZ login, CX send-your-data API key and CX "normal" API key for execution. 

# How Has This Been Tested?

Ran tests locally.

# Checklist:
- [x] This change does not affect any particular component (e.g. it's readme or docs change)