### PR TITLE
draft: E2E tests / stage2

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,7 @@ on:
     #   - master
       - e2e-stage2
     paths:
+      - ".github/**"
       - "StorageQueue/**"
       - "EventHub/**"
       - "DiagnosticData/**"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,8 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-    # Uncomment after Stage 2
-    #   - master
+      - master
       - e2e-stage2
     paths:
       - ".github/**"
@@ -14,10 +13,6 @@ on:
       - "DiagnosticData/**"
       - "BlobViaEventGrid/**"
       - "BlobToOtel/**"
-# Uncomment after Stage 2
-#   schedule:
-#     # Every morning 8am UTC
-#     - cron: "0 8 * * *"
 
 permissions:
   contents: read
@@ -32,35 +27,54 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-        if: github.event_name != 'schedule'
         with:
           fetch-depth: 0
 
-      # Temporarily disabled: always run all packages to verify tests on GitHub
-      # - name: Detect changed packages
-      #   uses: dorny/paths-filter@v3
-      #   id: changes
-      #   if: github.event_name == 'push'
-      #   with:
-      #     base: ${{ github.ref }}
-      #     filters: |
-      #       StorageQueue:
-      #         - 'StorageQueue/**'
-      #       EventHub:
-      #         - 'EventHub/**'
-      #       DiagnosticData:
-      #         - 'DiagnosticData/**'
-      #       BlobViaEventGrid:
-      #         - 'BlobViaEventGrid/**'
-      #       BlobToOtel:
-      #         - 'BlobToOtel/**'
+      - name: Detect changed packages
+        uses: dorny/paths-filter@v3
+        id: changes
+        if: github.event_name == 'push'
+        with:
+          base: ${{ github.event.before }}
+          filters: |
+            StorageQueue:
+              - 'StorageQueue/**'
+            EventHub:
+              - 'EventHub/**'
+            DiagnosticData:
+              - 'DiagnosticData/**'
+            BlobViaEventGrid:
+              - 'BlobViaEventGrid/**'
+            BlobToOtel:
+              - 'BlobToOtel/**'
 
       - name: Set packages matrix
         id: set-packages
+        env:
+          EVENT: ${{ github.event_name }}
+          SQ: ${{ steps.changes.outputs.StorageQueue }}
+          EH: ${{ steps.changes.outputs.EventHub }}
+          DD: ${{ steps.changes.outputs.DiagnosticData }}
+          BVE: ${{ steps.changes.outputs.BlobViaEventGrid }}
+          BTO: ${{ steps.changes.outputs.BlobToOtel }}
         run: |
-          # For now: always run all packages (detect-changes commented out)
-          echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
-          echo 'has-changes=true' >> $GITHUB_OUTPUT
+          if [[ "$EVENT" == "push" && ("$SQ" == "true" || "$EH" == "true" || "$DD" == "true" || "$BVE" == "true" || "$BTO" == "true") ]]; then
+            packages=()
+            [[ "$SQ" == "true" ]] && packages+=("StorageQueue")
+            [[ "$EH" == "true" ]] && packages+=("EventHub")
+            [[ "$DD" == "true" ]] && packages+=("DiagnosticData")
+            [[ "$BVE" == "true" ]] && packages+=("BlobViaEventGrid")
+            [[ "$BTO" == "true" ]] && packages+=("BlobToOtel")
+            pk_json=$(printf '%s\n' "${packages[@]}" | jq -R . | jq -s -c .)
+            echo "packages=$pk_json" >> $GITHUB_OUTPUT
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+          elif [[ "$EVENT" == "workflow_dispatch" ]]; then
+            echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
+            echo 'has-changes=true' >> $GITHUB_OUTPUT
+          else
+            echo 'packages=[]' >> $GITHUB_OUTPUT
+            echo 'has-changes=false' >> $GITHUB_OUTPUT
+          fi
 
   e2e:
     needs: detect-changes

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,18 +1,13 @@
 name: E2E Tests
 
 on:
-  workflow_dispatch:
-  push:
+  workflow_run:
+    workflows:
+      - "Build, Test & Release"
     branches:
       - master
-      - e2e-stage2
-    paths:
-      - ".github/**"
-      - "StorageQueue/**"
-      - "EventHub/**"
-      - "DiagnosticData/**"
-      - "BlobViaEventGrid/**"
-      - "BlobToOtel/**"
+    types:
+      - completed
 
 permissions:
   contents: read
@@ -21,6 +16,8 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
+    # For workflow_run: only proceed if the release workflow succeeded
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
       has-changes: ${{ steps.set-packages.outputs.has-changes }}
@@ -68,7 +65,7 @@ jobs:
             pk_json=$(printf '%s\n' "${packages[@]}" | jq -R . | jq -s -c .)
             echo "packages=$pk_json" >> $GITHUB_OUTPUT
             echo "has-changes=true" >> $GITHUB_OUTPUT
-          elif [[ "$EVENT" == "workflow_dispatch" ]]; then
+          elif [[ "$EVENT" == "workflow_dispatch" || "$EVENT" == "workflow_run" ]]; then
             echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
             echo 'has-changes=true' >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,7 @@
 name: E2E Tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
     # Uncomment after Stage 2
@@ -33,40 +34,31 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect changed packages
-        uses: dorny/paths-filter@v3
-        id: changes
-        if: github.event_name == 'push'
-        with:
-          base: ${{ github.ref }}
-          filters: |
-            StorageQueue:
-              - 'StorageQueue/**'
-            EventHub:
-              - 'EventHub/**'
-            DiagnosticData:
-              - 'DiagnosticData/**'
-            BlobViaEventGrid:
-              - 'BlobViaEventGrid/**'
-            BlobToOtel:
-              - 'BlobToOtel/**'
+      # Temporarily disabled: always run all packages to verify tests on GitHub
+      # - name: Detect changed packages
+      #   uses: dorny/paths-filter@v3
+      #   id: changes
+      #   if: github.event_name == 'push'
+      #   with:
+      #     base: ${{ github.ref }}
+      #     filters: |
+      #       StorageQueue:
+      #         - 'StorageQueue/**'
+      #       EventHub:
+      #         - 'EventHub/**'
+      #       DiagnosticData:
+      #         - 'DiagnosticData/**'
+      #       BlobViaEventGrid:
+      #         - 'BlobViaEventGrid/**'
+      #       BlobToOtel:
+      #         - 'BlobToOtel/**'
 
       - name: Set packages matrix
         id: set-packages
         run: |
-          # Delete 2nd part of the if statement after Stage 2
-          if [[ "${{ github.event_name }}" == "schedule" ]] || [[ "${{ github.ref }}" == "refs/heads/e2e-stage2" ]]; then
-            echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
-            echo 'has-changes=true' >> $GITHUB_OUTPUT
-          else
-            packages='${{ steps.changes.outputs.changes }}'
-            echo "packages=$packages" >> $GITHUB_OUTPUT
-            if [[ "$packages" == "[]" ]] || [[ -z "$packages" ]]; then
-              echo 'has-changes=false' >> $GITHUB_OUTPUT
-            else
-              echo 'has-changes=true' >> $GITHUB_OUTPUT
-            fi
-          fi
+          # For now: always run all packages (detect-changes commented out)
+          echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
+          echo 'has-changes=true' >> $GITHUB_OUTPUT
 
   e2e:
     needs: detect-changes

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,6 +21,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # required for Azure OIDC / federated login
 
 jobs:
   detect-changes:

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -40,9 +40,6 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
-  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
-    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
-  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -105,7 +105,11 @@ rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---
-FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+FUNCTION_APP_NAME=$(az functionapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+if [[ -z "${FUNCTION_APP_NAME:-}" ]]; then
+  err "Step 2c: No function app found in resource group $RG_NAME."
+  exit 1
+fi
 log "Step 2c: Syncing function triggers..."
 az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
 log "Step 2c: Waiting 15s for triggers to register..."

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -31,6 +31,10 @@ ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-se
 # Required
 : "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
 
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"
+CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
@@ -73,8 +77,8 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo "  $(build_param 'OtelEndpoint' "$OTEL_ENDPOINT"),"
   echo "  $(build_param 'CoralogixDirectMode' "${CORALOGIX_DIRECT_MODE:-false}"),"
   echo "  $(build_param 'CoralogixApiKey' "${CORALOGIX_API_KEY:-}"),"
-  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
-  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"),"
+  echo "  $(build_param 'CoralogixApplication' "$CX_APP"),"
+  echo "  $(build_param 'CoralogixSubsystem' "$CX_SUBSYS"),"
   echo '  "NewlinePattern": { "value": "(?:\\r\\n|\\r|\\n)" },'
   echo "  $(build_param 'EventHubNamespace' "$EVENTHUB_NAMESPACE"),"
   echo "  $(build_param 'EventHubName' "$EVENTHUB_NAME"),"
@@ -140,13 +144,13 @@ fetch_logs_count() {
     --data-urlencode "date_range.fromDate=$from" \
     --data-urlencode "date_range.toDate=$to" \
     --data-urlencode "resolution=10m" \
-    --data-urlencode "filters.application=azure" \
-    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "filters.application=$CX_APP" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
     --data-urlencode "subsystem_aggregation=true" \
     -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
 }
 
-log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
 attempt=0

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (prereqs + Event Hub consumer group).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send a test payload (upload a blob to trigger the function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -150,6 +150,7 @@ fetch_logs_count() {
 log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
 attempt=0
 while true; do
   attempt=$((attempt + 1))
@@ -158,11 +159,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 20 ]]; then
-    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 4: No logs received in Coralogix after $MAX_ATTEMPTS attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
   sleep 30
 done
 

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -5,6 +5,7 @@
 # Order of execution:
 #   1. Provision Azure resources with Terraform (prereqs + Event Hub consumer group).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (upload a blob to trigger the function).
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
@@ -102,6 +103,13 @@ az deployment group create \
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
+
+# --- Step 2c: Sync function triggers, then wait before sending data ---
+FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+log "Step 2c: Syncing function triggers..."
+az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
+log "Step 2c: Waiting 15s for triggers to register..."
+sleep 15
 
 # --- Step 3: Send test payload (upload blob to trigger function) ---
 log "Step 3: Uploading test blob to trigger the function..."

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -36,6 +36,9 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
+  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
+    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
+  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (prereqs + Event Hub consumer group).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send a test payload (upload a blob to trigger the function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -158,11 +158,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 10 ]]; then
-    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge 20 ]]; then
+    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
   sleep 30
 done
 

--- a/BlobToOtel/tests/terraform/main.tf
+++ b/BlobToOtel/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "blobtootel-e2e"
-  location    = "eastus"
+  location    = "canadacentral"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/BlobToOtel/tests/terraform/main.tf
+++ b/BlobToOtel/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "blobtootel-e2e"
-  location    = "canadacentral"
+  location    = "westeurope"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -47,9 +47,6 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
-  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
-    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
-  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -6,6 +6,7 @@
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, container).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #      The ARM template creates the Event Grid system topic and subscription to the function.
+#   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (upload a blob to trigger Event Grid → function).
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
@@ -99,6 +100,13 @@ az deployment group create \
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
+
+# --- Step 2c: Sync function triggers, then wait before sending data ---
+FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+log "Step 2c: Syncing function triggers..."
+az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
+log "Step 2c: Waiting 15s for triggers to register..."
+sleep 15
 
 # --- Step 3: Send test payload (upload blob to trigger Event Grid → function) ---
 log "Step 3: Uploading test blob to trigger Event Grid and the function..."

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -44,6 +44,9 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
+  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
+    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
+  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -7,7 +7,7 @@
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #      The ARM template creates the Event Grid system topic and subscription to the function.
 #   3. Send a test payload (upload a blob to trigger Event Grid → function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -147,6 +147,7 @@ fetch_logs_count() {
 log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
 attempt=0
 while true; do
   attempt=$((attempt + 1))
@@ -155,11 +156,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 20 ]]; then
-    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 4: No logs received in Coralogix after $MAX_ATTEMPTS attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
   sleep 30
 done
 

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -102,7 +102,11 @@ rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---
-FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+FUNCTION_APP_NAME=$(az functionapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+if [[ -z "${FUNCTION_APP_NAME:-}" ]]; then
+  err "Step 2c: No function app found in resource group $RG_NAME."
+  exit 1
+fi
 log "Step 2c: Syncing function triggers..."
 az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
 log "Step 2c: Waiting 15s for triggers to register..."

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -39,6 +39,9 @@ ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-se
 # For Step 4 verification
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
 
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
+
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
@@ -77,8 +80,8 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo '  "CoralogixRegion": { "value": "Custom" },'
   echo "  $(build_param 'CustomURL' "$OTEL_ENDPOINT"),"
   echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
-  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
-  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"),"
+  echo "  $(build_param 'CoralogixApplication' "$CX_APP"),"
+  echo "  $(build_param 'CoralogixSubsystem' "$CX_SUBSYS"),"
   echo "  $(build_param 'StorageAccountName' "$STORAGE_ACCOUNT"),"
   echo "  $(build_param 'StorageAccountResourceGroup' "$STORAGE_RG"),"
   echo "  $(build_param 'BlobContainerName' "$CONTAINER_NAME"),"
@@ -138,13 +141,13 @@ fetch_logs_count() {
     --data-urlencode "date_range.fromDate=$from" \
     --data-urlencode "date_range.toDate=$to" \
     --data-urlencode "resolution=10m" \
-    --data-urlencode "filters.application=azure" \
-    --data-urlencode "filters.subsystem=blob-storage-logs" \
+    --data-urlencode "filters.application=$CX_APP" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
     --data-urlencode "subsystem_aggregation=true" \
     -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
 }
 
-log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=blob-storage-logs)..."
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
 attempt=0

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -7,7 +7,7 @@
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #      The ARM template creates the Event Grid system topic and subscription to the function.
 #   3. Send a test payload (upload a blob to trigger Event Grid → function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -155,11 +155,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 10 ]]; then
-    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge 20 ]]; then
+    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
   sleep 30
 done
 

--- a/BlobViaEventGrid/tests/terraform/main.tf
+++ b/BlobViaEventGrid/tests/terraform/main.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "blobviaeg-e2e"
-  location    = "eastus"
+  location    = "canadacentral"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/BlobViaEventGrid/tests/terraform/main.tf
+++ b/BlobViaEventGrid/tests/terraform/main.tf
@@ -20,7 +20,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "blobviaeg-e2e"
-  location    = "canadacentral"
+  location    = "westeurope"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/DiagnosticData/tests/README.md
+++ b/DiagnosticData/tests/README.md
@@ -2,6 +2,8 @@
 
 End-to-end test for the **Diagnostic Data** Azure Function using real diagnostic settings: a storage account streams its **Transaction** metric to an Event Hub, the function reads from the Event Hub and forwards to Coralogix.
 
+**Note:** These tests are **unstable** by nature. Azure Diagnostic Settings for storage (metrics streamed to Event Hub) can take a long time to populate—sometimes **up to 1 hour**—so runs may succeed or fail intermittently depending on timing.
+
 ## Flow
 
 1. **Provision** – Terraform creates:

--- a/DiagnosticData/tests/README.md
+++ b/DiagnosticData/tests/README.md
@@ -55,7 +55,7 @@ Dependent resources are deployed via Terraform; the function is deployed via the
 ## Troubleshooting
 
 - **No logs in Coralogix** – Data is sent to `/azure/events/v1`; it may appear as logs (app/subsystem) or in another product area. Check the function’s Application Insights for `Sent messages. Response: 200` vs `4xx` to see if Coralogix accepted the request.
-- **Diagnostic data delay** – New diagnostic settings can take 1–2 minutes (or up to 90 in rare cases). Increase `WAIT_INITIAL` (e.g. 180) and `MAX_ATTEMPTS` if needed.
+- **Diagnostic data delay** – Diagnostic Settings for blob storage can take a long time to populate (from a few minutes **up to 1 hour**). The tests are inherently unstable for this reason. Increase `WAIT_INITIAL` and `MAX_ATTEMPTS` if needed; occasional failures are expected.
 - **Region** – Ensure `OTEL_ENDPOINT` matches your Coralogix region (e.g. `https://ingress.eu2.coralogix.com`).
 
 ## References

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -43,6 +43,9 @@ NUM_BLOBS="${NUM_BLOBS:-8}"
 # For Step 4 verification
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
 
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
+
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
@@ -85,8 +88,8 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo '  "CoralogixRegion": { "value": "Custom" },'
   echo "  $(build_param 'CustomURL' "$CORALOGIX_EVENTS_URL"),"
   echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
-  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
-  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"),"
+  echo "  $(build_param 'CoralogixApplication' "$CX_APP"),"
+  echo "  $(build_param 'CoralogixSubsystem' "$CX_SUBSYS"),"
   echo "  $(build_param 'EventhubResourceGroup' "$EVENTHUB_RG"),"
   echo "  $(build_param 'EventhubNamespace' "$EVENTHUB_NAMESPACE"),"
   echo "  $(build_param 'EventhubInstanceName' "$EVENTHUB_NAME"),"
@@ -138,8 +141,6 @@ CX_API_HOST="${CX_API_HOST%%:*}"
 CX_API_HOST="${CX_API_HOST%%/*}"
 CX_API_HOST="${CX_API_HOST/#ingress./api.}"
 CX_DATA_USAGE_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2"
-
-CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
 
 now_minus_60m() {
   if date -u -d '60 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -48,6 +48,9 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
+  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
+    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
+  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -105,7 +105,11 @@ rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---
-FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+FUNCTION_APP_NAME=$(az functionapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+if [[ -z "${FUNCTION_APP_NAME:-}" ]]; then
+  err "Step 2c: No function app found in resource group $RG_NAME."
+  exit 1
+fi
 log "Step 2c: Syncing function triggers..."
 az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
 log "Step 2c: Waiting 15s for triggers to register..."

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -6,6 +6,7 @@
 #   1. Provision Azure resources with Terraform (RG, Event Hub, storage account with
 #      diagnostic setting that streams Transaction metric to Event Hub).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Upload 5–10 blobs to the storage account to generate transactions; diagnostic setting
 #      streams data to Event Hub; function reads and forwards to Coralogix.
 #   4. Wait 2 min, then poll Coralogix Data Usage API until subsystem units > 0 (retry every 30s, up to 30 times).
@@ -102,6 +103,13 @@ az deployment group create \
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
+
+# --- Step 2c: Sync function triggers, then wait before sending data ---
+FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+log "Step 2c: Syncing function triggers..."
+az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
+log "Step 2c: Waiting 15s for triggers to register..."
+sleep 15
 
 # --- Step 3: Upload blobs to generate storage transactions (diagnostic setting streams to Event Hub) ---
 log "Step 3: Uploading $NUM_BLOBS blobs to container $CONTAINER_NAME to trigger diagnostic data..."

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -51,9 +51,6 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
-  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
-    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
-  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -8,7 +8,7 @@
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Upload 5–10 blobs to the storage account to generate transactions; diagnostic setting
 #      streams data to Event Hub; function reads and forwards to Coralogix.
-#   4. Wait 2 min, then poll Coralogix Data Usage API until subsystem units > 0 (retry every 30s, up to 15 times).
+#   4. Wait 2 min, then poll Coralogix Data Usage API until subsystem units > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -161,7 +161,7 @@ fetch_data_usage_units() {
 
 # Diagnostic data can take 1–2 minutes (or more) to flow: storage → Event Hub → function → Coralogix
 WAIT_INITIAL="${WAIT_INITIAL:-120}"
-MAX_ATTEMPTS="${MAX_ATTEMPTS:-15}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
 
 log "Step 4: Waiting ${WAIT_INITIAL}s for diagnostic data to flow, then verifying data in Coralogix (subsystem=$CX_SUBSYS, data usage units)..."
 sleep "$WAIT_INITIAL"

--- a/DiagnosticData/tests/terraform/main.tf
+++ b/DiagnosticData/tests/terraform/main.tf
@@ -27,7 +27,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "cx-diagdata-e2e"
-  location    = "eastus"
+  location    = "canadacentral"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/DiagnosticData/tests/terraform/main.tf
+++ b/DiagnosticData/tests/terraform/main.tf
@@ -27,7 +27,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "cx-diagdata-e2e"
-  location    = "canadacentral"
+  location    = "westeurope"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/EventHub/EventHub/index.ts
+++ b/EventHub/EventHub/index.ts
@@ -10,7 +10,6 @@
  * @since       1.0.0
  */
 
-// Dumb comment to trigger a build
 import { InvocationContext } from "@azure/functions";
 import { Logger } from "@opentelemetry/api-logs";
 import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";

--- a/EventHub/EventHub/index.ts
+++ b/EventHub/EventHub/index.ts
@@ -10,6 +10,7 @@
  * @since       1.0.0
  */
 
+// Dumb comment to trigger a build
 import { InvocationContext } from "@azure/functions";
 import { Logger } from "@opentelemetry/api-logs";
 import { LoggerProvider, BatchLogRecordProcessor } from "@opentelemetry/sdk-logs";

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send test events to the Event Hub to trigger the function.
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -145,6 +145,7 @@ fetch_logs_count() {
 log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
 attempt=0
 while true; do
   attempt=$((attempt + 1))
@@ -153,11 +154,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 20 ]]; then
-    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 4: No logs received in Coralogix after $MAX_ATTEMPTS attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
   sleep 30
 done
 

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -35,6 +35,8 @@ ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-se
 
 # For Step 4 verification
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
@@ -82,8 +84,8 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo '  "CoralogixRegion": { "value": "Custom" },'
   echo "  $(build_param 'CustomURL' "$CUSTOM_URL"),"
   echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
-  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
-  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"),"
+  echo "  $(build_param 'CoralogixApplication' "$CX_APP"),"
+  echo "  $(build_param 'CoralogixSubsystem' "$CX_SUBSYS"),"
   echo "  $(build_param 'EventhubResourceGroup' "$EVENTHUB_RG"),"
   echo "  $(build_param 'EventhubNamespace' "$EVENTHUB_NAMESPACE"),"
   echo "  $(build_param 'EventhubInstanceName' "$EVENTHUB_NAME"),"
@@ -128,9 +130,6 @@ now_minus_10m() {
   fi
   date -u -v-10M +%Y-%m-%dT%H:%M:%S.000Z
 }
-
-CX_APP="${CORALOGIX_APPLICATION:-azure}"
-CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
 
 fetch_logs_count() {
   local from to

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -41,6 +41,9 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
+  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
+    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
+  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send test events to the Event Hub to trigger the function.
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -153,11 +153,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 10 ]]; then
-    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge 20 ]]; then
+    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
   sleep 30
 done
 

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -106,7 +106,11 @@ rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---
-FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+FUNCTION_APP_NAME=$(az functionapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+if [[ -z "${FUNCTION_APP_NAME:-}" ]]; then
+  err "Step 2c: No function app found in resource group $RG_NAME."
+  exit 1
+fi
 log "Step 2c: Syncing function triggers..."
 az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
 log "Step 2c: Waiting 15s for triggers to register..."

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -5,6 +5,7 @@
 # Order of execution:
 #   1. Provision Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send test events to the Event Hub to trigger the function.
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
@@ -103,6 +104,13 @@ az deployment group create \
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
+
+# --- Step 2c: Sync function triggers, then wait before sending data ---
+FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+log "Step 2c: Syncing function triggers..."
+az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
+log "Step 2c: Waiting 15s for triggers to register..."
+sleep 15
 
 # --- Step 3: Send test events to Event Hub to trigger the function ---
 log "Step 3: Sending test event (JSON payload) to Event Hub..."

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -43,9 +43,6 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
 cleanup_after_failure() {
   log "Cleaning up after failure..."
-  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
-    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
-  fi
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi

--- a/EventHub/tests/terraform/main.tf
+++ b/EventHub/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "cx-eventhub-e2e"
-  location    = "eastus"
+  location    = "canadacentral"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/EventHub/tests/terraform/main.tf
+++ b/EventHub/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "cx-eventhub-e2e"
-  location    = "canadacentral"
+  location    = "westeurope"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -50,16 +50,13 @@ fi
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
-cleanup_after_failure() {
-  log "Cleaning up after failure..."
-  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
-    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
-  fi
-  if [[ -n "${RG_NAME:-}" ]]; then
-    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
-  fi
-}
-trap cleanup_after_failure EXIT
+# cleanup_after_failure() {
+#   log "Cleaning up after failure..."
+#   if [[ -n "${RG_NAME:-}" ]]; then
+#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+#   fi
+# }
+# trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -48,13 +48,16 @@ fi
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
-# cleanup_after_failure() {
-#   log "Cleaning up after failure..."
-#   if [[ -n "${RG_NAME:-}" ]]; then
-#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
-#   fi
-# }
-# trap cleanup_after_failure EXIT
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -d "${TERRAFORM_DIR:-}" ]]; then
+    (cd "$TERRAFORM_DIR" && terraform destroy -input=false -auto-approve 2>/dev/null) || true
+  fi
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -37,6 +37,8 @@ ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-se
 
 # For Step 4 verification
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"
+CX_APP="${CORALOGIX_APPLICATION:-azure}"
+CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
 
 # Coralogix logs API URL (ARM CustomURL expects full URL, e.g. https://ingress.XXX/api/v1/logs)
 if [[ "$OTEL_ENDPOINT" == *"/api/v1/logs" ]]; then
@@ -83,8 +85,8 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo '  "CoralogixRegion": { "value": "Custom" },'
   echo "  $(build_param 'CustomURL' "$CORALOGIX_LOGS_URL"),"
   echo "  $(build_param 'CoralogixPrivateKey' "$CORALOGIX_API_KEY"),"
-  echo "  $(build_param 'CoralogixApplication' "${CORALOGIX_APPLICATION:-azure}"),"
-  echo "  $(build_param 'CoralogixSubsystem' "${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"),"
+  echo "  $(build_param 'CoralogixApplication' "$CX_APP"),"
+  echo "  $(build_param 'CoralogixSubsystem' "$CX_SUBSYS"),"
   echo "  $(build_param 'StorageAccountName' "$STORAGE_ACCOUNT"),"
   echo "  $(build_param 'StorageAccountResourceGroup' "$STORAGE_RG"),"
   echo "  $(build_param 'StorageQueueName' "$STORAGE_QUEUE_NAME"),"
@@ -119,9 +121,6 @@ CX_API_HOST="${CX_API_HOST%%:*}"
 CX_API_HOST="${CX_API_HOST/#ingress./api.}"
 CX_LOGS_COUNT_URL="https://${CX_API_HOST}/mgmt/openapi/latest/dataplans/data-usage/v2/logs:count"
 
-# Subsystem used in ARM parameters (must match build_param above)
-CX_SUBSYSTEM="${CORALOGIX_SUBSYSTEM:-storage-queue-e2e}"
-
 now_minus_10m() {
   if date -u -d '10 min ago' +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null; then
     return
@@ -137,13 +136,13 @@ fetch_logs_count() {
     --data-urlencode "date_range.fromDate=$from" \
     --data-urlencode "date_range.toDate=$to" \
     --data-urlencode "resolution=10m" \
-    --data-urlencode "filters.application=azure" \
-    --data-urlencode "filters.subsystem=$CX_SUBSYSTEM" \
+    --data-urlencode "filters.application=$CX_APP" \
+    --data-urlencode "filters.subsystem=$CX_SUBSYS" \
     --data-urlencode "subsystem_aggregation=true" \
     -H "Authorization: Bearer $CORALOGIX_QUERY_API_KEY" | head -1 | jq -r '(.result.logsCount // []) | map(.logsCount | tonumber) | add // 0'
 }
 
-log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=azure, subsystem=$CX_SUBSYSTEM)..."
+log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
 attempt=0

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -101,7 +101,11 @@ rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---
-FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+FUNCTION_APP_NAME=$(az functionapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+if [[ -z "${FUNCTION_APP_NAME:-}" ]]; then
+  err "Step 2c: No function app found in resource group $RG_NAME."
+  exit 1
+fi
 log "Step 2c: Syncing function triggers..."
 az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
 log "Step 2c: Waiting 15s for triggers to register..."

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, queue).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send a test payload (put a JSON message into the storage queue to trigger the function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -142,6 +142,7 @@ fetch_logs_count() {
 log "Step 4: Waiting 30s, then verifying logs in Coralogix (app=$CX_APP, subsystem=$CX_SUBSYS)..."
 sleep 30
 
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-30}"
 attempt=0
 while true; do
   attempt=$((attempt + 1))
@@ -150,11 +151,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 20 ]]; then
-    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge "$MAX_ATTEMPTS" ]]; then
+    err "Step 4: No logs received in Coralogix after $MAX_ATTEMPTS attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/$MAX_ATTEMPTS), retrying in 30s..."
   sleep 30
 done
 

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -50,13 +50,13 @@ fi
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
-# cleanup_after_failure() {
-#   log "Cleaning up after failure..."
-#   if [[ -n "${RG_NAME:-}" ]]; then
-#     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
-#   fi
-# }
-# trap cleanup_after_failure EXIT
+cleanup_after_failure() {
+  log "Cleaning up after failure..."
+  if [[ -n "${RG_NAME:-}" ]]; then
+    az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  fi
+}
+trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."
@@ -159,15 +159,15 @@ while true; do
 done
 
 # --- Step 5: Clean up ---
-# log "Step 5: Cleaning up resources..."
-# trap - EXIT
-# az group delete --name "$RG_NAME" --yes
-# log "Waiting for resource group deletion..."
-# while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
-# # Clean Terraform state so next run can provision from scratch.
-# cd "$TERRAFORM_DIR"
-# while read -r state_key; do
-#   [[ -z "$state_key" ]] && continue
-#   terraform state rm "$state_key" 2>/dev/null || true
-# done < <(terraform state list 2>/dev/null || true)
+log "Step 5: Cleaning up resources..."
+trap - EXIT
+az group delete --name "$RG_NAME" --yes
+log "Waiting for resource group deletion..."
+while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
+# Clean Terraform state so next run can provision from scratch.
+cd "$TERRAFORM_DIR"
+while read -r state_key; do
+  [[ -z "$state_key" ]] && continue
+  terraform state rm "$state_key" 2>/dev/null || true
+done < <(terraform state list 2>/dev/null || true)
 log "E2E test finished."

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -6,7 +6,7 @@
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, queue).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
 #   3. Send a test payload (put a JSON message into the storage queue to trigger the function).
-#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 10 times).
+#   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 20 times).
 #   5. Clean up all resources.
 #
 # Prerequisites:
@@ -150,11 +150,11 @@ while true; do
     log "Step 4: Logs verified in Coralogix (count=$count)."
     break
   fi
-  if [[ $attempt -ge 10 ]]; then
-    err "Step 4: No logs received in Coralogix after 10 attempts (last count=${count:-unknown})."
+  if [[ $attempt -ge 20 ]]; then
+    err "Step 4: No logs received in Coralogix after 20 attempts (last count=${count:-unknown})."
     exit 1
   fi
-  log "Step 4: No logs yet (attempt $attempt/10), retrying in 30s..."
+  log "Step 4: No logs yet (attempt $attempt/20), retrying in 30s..."
   sleep 30
 done
 

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -5,6 +5,7 @@
 # Order of execution:
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, queue).
 #   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (put a JSON message into the storage queue to trigger the function).
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
 #   5. Clean up all resources.
@@ -98,6 +99,13 @@ az deployment group create \
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."
+
+# --- Step 2c: Sync function triggers, then wait before sending data ---
+FUNCTION_APP_NAME=$(az webapp list --resource-group "$RG_NAME" --query "[0].name" -o tsv)
+log "Step 2c: Syncing function triggers..."
+az resource invoke-action -g "$RG_NAME" -n "$FUNCTION_APP_NAME" --action syncfunctiontriggers --resource-type Microsoft.Web/sites
+log "Step 2c: Waiting 15s for triggers to register..."
+sleep 15
 
 # --- Step 3: Send test payload (put JSON message into queue to trigger function) ---
 # Storage Queue messages are base64-encoded. Function expects JSON-formatted queue messages.

--- a/StorageQueue/tests/terraform/main.tf
+++ b/StorageQueue/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "storagequeue-e2e"
-  location    = "eastus"
+  location    = "canadacentral"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM into this RG)

--- a/StorageQueue/tests/terraform/main.tf
+++ b/StorageQueue/tests/terraform/main.tf
@@ -21,7 +21,7 @@ provider "azurerm" {
 
 locals {
   name_prefix = "storagequeue-e2e"
-  location    = "canadacentral"
+  location    = "westeurope"
 }
 
 # Single resource group for the e2e test (prereqs; function is deployed via ARM into this RG)


### PR DESCRIPTION
# Description

Fixes CDS-2468. Finalizes E2E tests workflow on this repo.

Changes:

1. Finalized the workflow, runs on `master` branch, only testing packages that were changed.
2. Stabilized the tests by adding `syncfunctiontriggers` before sending data
3. Moved application/subsystem to dedicated variable that can be configured via env
4. Increased max attempts to check CX API to 30 in case if the log delivery gets delayed (might happen very rarely)
5. Moved the region from `eastus` to `westeurope`
6. Documented the instable nature of `DiagnosticsData` test (won't be invoked anyway, as this function is practically deprecated).

# How Has This Been Tested?

Constantly run GitHub Actions until reaching the desired result.

# Checklist:
- [x] This change does not affect any particular component (e.g. it's readme or docs change)