### PR TITLE
feat(EventHub): add optional metadata attributes via IncludeMetadata parameter

### DIFF
--- a/EventHub/ARM/EventHubV2.json
+++ b/EventHub/ARM/EventHubV2.json
@@ -120,6 +120,13 @@
       "metadata": {
         "description": "Optional: Regex pattern to block/filter logs. Logs matching this pattern will not be sent to Coralogix. Example: 'healthcheck|heartbeat' to filter health checks."
       }
+    },
+    "IncludeMetadata": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Optional: When enabled, attaches additional metadata to each log record: invocation thread ID, message index, and Azure resource attributes (subscription ID, resource group, provider) parsed from the log payload."
+      }
     }
   },
   "variables": {
@@ -129,7 +136,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "storageAccountName": "[format('azfunctions{0}', uniqueString(resourceGroup().id))]",
     "location": "[resourceGroup().location]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.6.1/EventHub-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.0/EventHub-FunctionApp.zip",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', 'EP1')]"
   },
   "resources": [
@@ -280,6 +287,10 @@
             {
               "name": "CORALOGIX_SUBSYSTEM_SELECTOR",
               "value": "[parameters('CoralogixSubsystemSelector')]"
+            },
+            {
+              "name": "INCLUDE_METADATA",
+              "value": "[string(parameters('IncludeMetadata'))]"
             }
           ]
         }

--- a/EventHub/CHANGELOG.md
+++ b/EventHub/CHANGELOG.md
@@ -1,3 +1,15 @@
+### 3.8.0 / 01 Apr 2026
+[FEATURE] Optional metadata attributes via `IncludeMetadata` parameter:
+* Added `IncludeMetadata` ARM template parameter (default: `false`) to opt-in to additional OTel attributes per log record
+* When enabled, attaches `threadId`, `message.index`, `azure.subscription_id`, `azure.resource_group`, and `azure.provider` to each log
+* `function.name` is always included regardless of the setting
+
+### 3.7.1
+[CI] E2E test pipeline improvements
+
+### 3.7.0
+[TEST] Initial E2E test setup
+
 ### 3.6.1 / 16 Dec 2024
 [REFACTOR]
 * Remove `handleEventHubMessage` wrapper function

--- a/EventHub/EventHub/index.ts
+++ b/EventHub/EventHub/index.ts
@@ -6,7 +6,7 @@
  * @link        https://coralogix.com/
  * @copyright   Coralogix Ltd.
  * @licence     Apache-2.0
- * @version     3.6.1
+ * @version     3.8.0
  * @since       1.0.0
  */
 
@@ -25,6 +25,7 @@ const APPLICATION_SELECTOR = process.env.CORALOGIX_APPLICATION_SELECTOR;
 const SUBSYSTEM_SELECTOR = process.env.CORALOGIX_SUBSYSTEM_SELECTOR;
 
 const FUNCTION_NAME = process.env.FUNCTION_APP_NAME || "unknown";
+const INCLUDE_METADATA = process.env.INCLUDE_METADATA === "true";
 
 const NEWLINE_PATTERN = process.env.NEWLINE_PATTERN;
 const NEWLINE_REGEX = NEWLINE_PATTERN ? new RegExp(NEWLINE_PATTERN, "g") : null;
@@ -175,9 +176,8 @@ const writeLog = function (
 ): void {
   if (!text) return;
   const attributes: Record<string, any> = {
-    threadId,
     "function.name": FUNCTION_NAME,
-    "message.index": idx,
+    ...(INCLUDE_METADATA && { threadId, "message.index": idx }),
   };
 
   try {
@@ -185,7 +185,7 @@ const writeLog = function (
     const logEntries = handleLogEntries(text, format, context);
 
     for (const { body, parsedBody } of logEntries) {
-      if (parsedBody) {
+      if (INCLUDE_METADATA && parsedBody) {
         enrichAzureMetadata(attributes, parsedBody);
       }
 

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.6.1",
+  "version": "3.8.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/EventHub/tests/index.test.ts
+++ b/EventHub/tests/index.test.ts
@@ -524,3 +524,153 @@ describe("Log processing + blocking + splitting behaviour", () => {
     });
   });
 });
+
+describe("INCLUDE_METADATA behaviour", () => {
+  let emittedRecords: Array<{ body: any; attributes: Record<string, any> }>;
+  let mockContext: InvocationContext;
+
+  function loadWithMockedOtel(env: Record<string, string> = {}) {
+    emittedRecords = [];
+    const originalEnv = { ...process.env };
+    for (const [key, value] of Object.entries(env)) {
+      process.env[key] = value;
+    }
+
+    let mod: any;
+    jest.isolateModules(() => {
+      jest.doMock("@opentelemetry/sdk-logs", () => {
+        const emit = jest.fn((record: any) => emittedRecords.push(record));
+        const logger = { emit };
+        const provider = {
+          getLogger: jest.fn().mockReturnValue(logger),
+          addLogRecordProcessor: jest.fn(),
+          forceFlush: jest.fn().mockResolvedValue(undefined),
+        };
+        return {
+          LoggerProvider: jest.fn().mockReturnValue(provider),
+          BatchLogRecordProcessor: jest.fn(),
+        };
+      });
+      jest.doMock("@opentelemetry/exporter-logs-otlp-grpc", () => ({
+        OTLPLogExporter: jest.fn(),
+      }));
+      mod = require("../EventHub/index");
+    });
+
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+
+    return mod;
+  }
+
+  beforeEach(() => {
+    mockContext = createMockContext();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it("omits extra metadata by default (INCLUDE_METADATA not set)", async () => {
+    const { eventHubTrigger } = loadWithMockedOtel({ FUNCTION_APP_NAME: "my-func" });
+    const event = {
+      resourceId:
+        "/subscriptions/sub-abc/resourceGroups/prod-rg/providers/Microsoft.Storage/storageAccounts/mystorage",
+    };
+
+    const trigger = eventHubTrigger(mockContext, [event]);
+    jest.runAllTimers();
+    await trigger;
+
+    expect(emittedRecords).toHaveLength(1);
+    const attrs = emittedRecords[0].attributes;
+    expect(attrs["function.name"]).toBe("my-func");
+    expect(attrs).not.toHaveProperty("threadId");
+    expect(attrs).not.toHaveProperty("message.index");
+    expect(attrs).not.toHaveProperty("azure.subscription_id");
+    expect(attrs).not.toHaveProperty("azure.resource_group");
+    expect(attrs).not.toHaveProperty("azure.provider");
+  });
+
+  it("omits extra metadata when INCLUDE_METADATA=false", async () => {
+    const { eventHubTrigger } = loadWithMockedOtel({
+      FUNCTION_APP_NAME: "my-func",
+      INCLUDE_METADATA: "false",
+    });
+
+    const trigger = eventHubTrigger(mockContext, ["plain log"]);
+    jest.runAllTimers();
+    await trigger;
+
+    expect(emittedRecords).toHaveLength(1);
+    const attrs = emittedRecords[0].attributes;
+    expect(attrs["function.name"]).toBe("my-func");
+    expect(attrs).not.toHaveProperty("threadId");
+    expect(attrs).not.toHaveProperty("message.index");
+  });
+
+  it("includes all metadata attributes when INCLUDE_METADATA=true", async () => {
+    const { eventHubTrigger } = loadWithMockedOtel({
+      FUNCTION_APP_NAME: "my-func",
+      INCLUDE_METADATA: "true",
+    });
+    const event = {
+      resourceId:
+        "/subscriptions/sub-abc/resourceGroups/prod-rg/providers/Microsoft.Storage/storageAccounts/mystorage",
+    };
+
+    const trigger = eventHubTrigger(mockContext, [event]);
+    jest.runAllTimers();
+    await trigger;
+
+    expect(emittedRecords).toHaveLength(1);
+    const attrs = emittedRecords[0].attributes;
+    expect(attrs["function.name"]).toBe("my-func");
+    expect(attrs.threadId).toBe("test-id");
+    expect(attrs["message.index"]).toBe(0);
+    expect(attrs["azure.subscription_id"]).toBe("sub-abc");
+    expect(attrs["azure.resource_group"]).toBe("prod-rg");
+    expect(attrs["azure.provider"]).toBe("microsoft.storage");
+  });
+
+  it("does not include azure attributes when INCLUDE_METADATA=false even if resourceId is present", async () => {
+    const { eventHubTrigger } = loadWithMockedOtel({
+      FUNCTION_APP_NAME: "my-func",
+      INCLUDE_METADATA: "false",
+    });
+    const event = {
+      resourceId:
+        "/subscriptions/sub-abc/resourceGroups/prod-rg/providers/Microsoft.Storage",
+    };
+
+    const trigger = eventHubTrigger(mockContext, [event]);
+    jest.runAllTimers();
+    await trigger;
+
+    expect(emittedRecords).toHaveLength(1);
+    const attrs = emittedRecords[0].attributes;
+    expect(attrs).not.toHaveProperty("azure.subscription_id");
+    expect(attrs).not.toHaveProperty("azure.resource_group");
+    expect(attrs).not.toHaveProperty("azure.provider");
+  });
+
+  it("always includes function.name regardless of INCLUDE_METADATA value", async () => {
+    for (const metadataVal of [undefined, "false", "true"]) {
+      emittedRecords = [];
+      const env: Record<string, string> = { FUNCTION_APP_NAME: "always-present-func" };
+      if (metadataVal !== undefined) env.INCLUDE_METADATA = metadataVal;
+
+      const { eventHubTrigger } = loadWithMockedOtel(env);
+      const trigger = eventHubTrigger(mockContext, ["some log"]);
+      jest.runAllTimers();
+      await trigger;
+
+      expect(emittedRecords.length).toBeGreaterThan(0);
+      expect(emittedRecords[0].attributes["function.name"]).toBe("always-present-func");
+    }
+  });
+});

--- a/EventHub/tsconfig.json
+++ b/EventHub/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "sourceMap": true,
-    "strict": false
+    "strict": false,
+    "types": ["jest", "node"]
   }
 }


### PR DESCRIPTION
- Added INCLUDE_METADATA env var (default: false) to opt-in to additional OTel attributes per log record
- When enabled, attaches threadId, message.index, azure.subscription_id, azure.resource_group, and azure.provider to each log
- function.name is always included regardless of the setting
- Added IncludeMetadata bool parameter to EventHubV2.json ARM template (default: false)
- Added unit tests for INCLUDE_METADATA behaviour
- Bumped version to 3.8.0

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the version in the relevant file.
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)