### PR TITLE
fix: trigger rebuild of indirect dependencies

### DIFF
--- a/BlobToOtel/ARM/BlobToOtel.json
+++ b/BlobToOtel/ARM/BlobToOtel.json
@@ -168,7 +168,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "functionStorageAccountName": "[format('func{0}', uniqueString(resourceGroup().id))]",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', parameters('PremiumPlanSku'))]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.1/BlobToOtel-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.2/BlobToOtel-FunctionApp.zip",
     "vnetIntegrationEnabled": "[and(not(empty(parameters('VirtualNetworkName'))), not(empty(parameters('SubnetName'))))]"
   },
   "resources": [

--- a/BlobToOtel/package.json
+++ b/BlobToOtel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.0.0",
+  "version": "3.0.2",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/BlobViaEventGrid/package.json
+++ b/BlobViaEventGrid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/EventHub/ARM/EventHubV2.json
+++ b/EventHub/ARM/EventHubV2.json
@@ -136,7 +136,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "storageAccountName": "[format('azfunctions{0}', uniqueString(resourceGroup().id))]",
     "location": "[resourceGroup().location]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.0/EventHub-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.1/EventHub-FunctionApp.zip",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', 'EP1')]"
   },
   "resources": [

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",


### PR DESCRIPTION
# Description

Fixes CDS-2983 by triggering rebuild of indirect dependencies in order to fix the exploited CVE vulnerability of `protobufjs`.

Changelog update isn't needed