### PR TITLE
fix(EventHub): upgrade OpenTelemetry dependencies for CVE-2026-54285

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ project.lock.json
 appsettings.json
 package-lock.json
 local.settings.json
+eventhub-parameters.json
 
 node_modules
 dist

--- a/EventHub/ARM/EventHubV2.json
+++ b/EventHub/ARM/EventHubV2.json
@@ -136,7 +136,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "storageAccountName": "[format('azfunctions{0}', uniqueString(resourceGroup().id))]",
     "location": "[resourceGroup().location]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.1/EventHub-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.3/EventHub-FunctionApp.zip",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', 'EP1')]"
   },
   "resources": [

--- a/EventHub/CHANGELOG.md
+++ b/EventHub/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 3.8.3 / 20 Jul 2026
+[FIX] Upgrade OpenTelemetry dependencies for CVE-2026-54285
+
 ### 3.8.0 / 01 Apr 2026
 [FEATURE] Optional metadata attributes via `IncludeMetadata` parameter:
 * Added `IncludeMetadata` ARM template parameter (default: `false`) to opt-in to additional OTel attributes per log record

--- a/EventHub/EventHub/index.ts
+++ b/EventHub/EventHub/index.ts
@@ -46,19 +46,14 @@ const loggerCache = new Map<string, LoggerCacheEntry>();
 
 function createLoggerProvider(resourceAttributes: Record<string, any>): LoggerProvider {
   const resource = resourceFromAttributes(resourceAttributes);
-  const loggerProvider = new LoggerProvider({ resource });
-
   const otlpExporter = new OTLPLogExporter();
+  const logRecordProcessor = new BatchLogRecordProcessor(otlpExporter, {
+    maxExportBatchSize: 512,
+    scheduledDelayMillis: 1000,
+    exportTimeoutMillis: 30000,
+  });
 
-  loggerProvider.addLogRecordProcessor(
-    new BatchLogRecordProcessor(otlpExporter, {
-      maxExportBatchSize: 512,
-      scheduledDelayMillis: 1000,
-      exportTimeoutMillis: 30000,
-    })
-  );
-
-  return loggerProvider;
+  return new LoggerProvider({ resource, processors: [logRecordProcessor] });
 }
 
 // Get or create a logger for a specific app/subsystem combination.

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -82,10 +82,10 @@
   },
   "dependencies": {
     "@azure/functions": "^4.7.0",
-    "@opentelemetry/api-logs": "^0.200.0",
-    "@opentelemetry/exporter-logs-otlp-grpc": "^0.200.0",
-    "@opentelemetry/resources": "^2.0.0",
-    "@opentelemetry/sdk-logs": "^0.200.0",
+    "@opentelemetry/api-logs": "^0.219.0",
+    "@opentelemetry/exporter-logs-otlp-grpc": "^0.219.0",
+    "@opentelemetry/resources": "2.8.0",
+    "@opentelemetry/sdk-logs": "^0.219.0",
     "@opentelemetry/semantic-conventions": "^1.30.0"
   },
   "files": [

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.8.1",
+  "version": "3.8.3",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",


### PR DESCRIPTION
Update the logging SDK family together and adopt its processor configuration API so release artifacts resolve to a patched OpenTelemetry core.

# Description

<!-- Please describe the changes you made in a few words or sentences. -->

<!-- (provide issue number, if applicable; otherwise remove) --> Fixes #

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

# Checklist:
- [ ] I have updated the version in the relevant file.
- [ ] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)