### PR TITLE
feat(domains): migrate legacy Coralogix domains to the regional domains

### DIFF
--- a/BlobToOtel/ARM/BlobToOtel.json
+++ b/BlobToOtel/ARM/BlobToOtel.json
@@ -168,7 +168,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "functionStorageAccountName": "[format('func{0}', uniqueString(resourceGroup().id))]",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', parameters('PremiumPlanSku'))]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.2/BlobToOtel-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.2.0/BlobToOtel-FunctionApp.zip",
     "vnetIntegrationEnabled": "[and(not(empty(parameters('VirtualNetworkName'))), not(empty(parameters('SubnetName'))))]"
   },
   "resources": [

--- a/BlobToOtel/CHANGELOG.md
+++ b/BlobToOtel/CHANGELOG.md
@@ -5,6 +5,10 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 3.2.0 / 11 Aug 2026
+* [Update] Use the regional Coralogix domain in the e2e test docs and script defaults (`ingress.eu1.coralogix.com`)
+* [Update] Point the ARM `packageUri` at `BlobToOtel-v3.2.0` (it referenced a release that was never published)
+
 ### 3.0.1 / 06 Feb 2026 
 * [Update] Use GitHub releases for ARM template deployment instead of S3
   - Updated ARM template to download function app from GitHub releases

--- a/BlobToOtel/package.json
+++ b/BlobToOtel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.0.2",
+  "version": "3.2.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/BlobToOtel/tests/README.md
+++ b/BlobToOtel/tests/README.md
@@ -41,7 +41,7 @@ export CORALOGIX_API_KEY="..."
 For Coralogix direct mode (OTLP to Coralogix):
 
 ```bash
-export OTEL_ENDPOINT="https://ingress.coralogix.com"
+export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
 export CORALOGIX_DIRECT_MODE=true
 export CORALOGIX_API_KEY="your-send-your-data-api-key"
 export CORALOGIX_QUERY_API_KEY="your-query-api-key" # – for Step 4 (Data Usage read)

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -15,7 +15,7 @@
 #   - Terraform >= 1.7.4.
 #   - jq (for parsing Coralogix API response).
 #   - Environment variables (or export before running):
-#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.coralogix.com
+#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.eu1.coralogix.com
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
 #     - Optional: CORALOGIX_DIRECT_MODE, CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
 #
@@ -30,7 +30,7 @@ TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobToOtel/ARM/BlobToOtel.json"
 
 # Required
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 
 CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventhub-e2e}"
 CORALOGIX_QUERY_API_KEY="${CORALOGIX_QUERY_API_KEY:-${CORALOGIX_API_KEY}}"

--- a/BlobViaEventGrid/ARM/BlobViaEventGrid.json
+++ b/BlobViaEventGrid/ARM/BlobViaEventGrid.json
@@ -4,8 +4,16 @@
   "parameters": {
     "CoralogixRegion": {
       "type": "string",
-      "defaultValue": "Europe(eu-west-1)",
+      "defaultValue": "EU1",
       "allowedValues": [
+        "EU1",
+        "EU2",
+        "US1",
+        "US2",
+        "US3",
+        "AP1",
+        "AP2",
+        "AP3",
         "Europe(eu-west-1)",
         "US(us-east-2)",
         "US2(us-west-2)",
@@ -15,7 +23,7 @@
         "Custom"
       ],
       "metadata": {
-        "description": "The region of the Coralogix account."
+        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), US3 (Iowa), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta). The legacy region names are still accepted and map to the same endpoints."
       }
     },
     "CustomURL": {
@@ -124,7 +132,8 @@
     }
   },
   "variables": {
-    "OtelEndpoint": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'https://ingress.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'https://ingress.coralogix.us:443', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'https://ingress.cx498.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'https://ingress.eu2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'https://ingress.coralogix.in:443', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'https://ingress.coralogixsg.com:443', 'https://ingress.eu2.coralogix.com:443')))))))]",
+    "CoralogixRegionCode": "[if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'EU1', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'US1', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'US2', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'EU2', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'AP1', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'AP2', parameters('CoralogixRegion')))))))]",
+    "OtelEndpoint": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(variables('CoralogixRegionCode'), 'EU1'), 'https://ingress.eu1.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'EU2'), 'https://ingress.eu2.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'US1'), 'https://ingress.us1.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'US2'), 'https://ingress.us2.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'US3'), 'https://ingress.us3.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'AP1'), 'https://ingress.ap1.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'AP2'), 'https://ingress.ap2.coralogix.com:443', if(equals(variables('CoralogixRegionCode'), 'AP3'), 'https://ingress.ap3.coralogix.com:443', 'https://ingress.eu2.coralogix.com:443')))))))))]",
     "functionAppName": "[format('BlobStorage-{0}', uniqueString(concat(resourceGroup().id, parameters('StorageAccountName'), parameters('BlobContainerName'))))]",
     "functionAppResourceGroupName": "[resourceGroup().name]",
     "location": "[resourceGroup().location]",

--- a/BlobViaEventGrid/CHANGELOG.md
+++ b/BlobViaEventGrid/CHANGELOG.md
@@ -5,6 +5,12 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 2.2.0 / 11 Aug 2026
+* [Update] Migrate legacy Coralogix domains to the regional domains
+  - `CoralogixRegion` now accepts the region codes `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`
+  - The legacy region names (`Europe(eu-west-1)`, `US(us-east-2)`, `US2(us-west-2)`, `Europe2(eu-north-1)`, `India(ap-south-1)`, `Singapore(ap-southeast-1)`) are still accepted and map to the same endpoints
+  - Endpoints now use `ingress.<region>.coralogix.com`; default region is `EU1`
+
 ### 2.1.3 / 06 Jul 2026
 * [Update] fix(deps): Override @grpc/grpc-js and protobufjs versions to resolve HIGH severity CVEs
 

--- a/BlobViaEventGrid/Makefile
+++ b/BlobViaEventGrid/Makefile
@@ -5,14 +5,17 @@ export CORALOGIX_APP_NAME ?= Azure
 export CORALOGIX_SUB_SYSTEM ?= "BlobViaEventGrid"
 export NEWLINE_PATTERN ?= (?:\r\n|\r|\n)
 
-#  Cluster	                API Endpoint
-#  .com	                    https://ingress.coralogix.com:443/api/v1/logs
-#  .us	                    https://ingress.coralogix.us:443/api/v1/logs
-#  .in	                    https://ingress.app.coralogix.in:443/api/v1/logs
-#  .app.eu2.coralogix.com	https://ingress.eu2.coralogix.com:443/api/v1/logs
-#  .app.coralogixsg.com	    https://ingress.coralogixsg.com:443/api/v1/logs
+#  Region	Endpoint
+#  EU1	https://ingress.eu1.coralogix.com:443/api/v1/logs
+#  EU2	https://ingress.eu2.coralogix.com:443/api/v1/logs
+#  US1	https://ingress.us1.coralogix.com:443/api/v1/logs
+#  US2	https://ingress.us2.coralogix.com:443/api/v1/logs
+#  US3	https://ingress.us3.coralogix.com:443/api/v1/logs
+#  AP1	https://ingress.ap1.coralogix.com:443/api/v1/logs
+#  AP2	https://ingress.ap2.coralogix.com:443/api/v1/logs
+#  AP3	https://ingress.ap3.coralogix.com:443/api/v1/logs
 
-export CORALOGIX_URL ?= "https://ingress.coralogixsg.com/api/v1/logs"
+export CORALOGIX_URL ?= "https://ingress.ap2.coralogix.com/api/v1/logs"
 
 # Fixed exports
 export AZURE_RESOURCE_GROUP ?= CrlgxRG$(UUID)

--- a/BlobViaEventGrid/README.md
+++ b/BlobViaEventGrid/README.md
@@ -26,7 +26,7 @@ The BlobStorage Via Eventgrid trigger integration can be deployed by clicking th
 
 **Resource Group** - The Resource Group into which you wish to deploy the integration.
 
-**Coralogix Region** - The region of the Coralogix account.
+**Coralogix Region** - The region of the Coralogix account (EU1, EU2, US1, US2, US3, AP1, AP2, AP3, or Custom). The legacy region names are still accepted and map to the same endpoints. For more details see [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/).
 
 **Coralogix Private Key** – Can be found in your Coralogix account under Settings -> Send your logs. It is located in the upper left corner.
 

--- a/BlobViaEventGrid/package.json
+++ b/BlobViaEventGrid/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -16,7 +16,7 @@
 #   - Terraform >= 1.7.4.
 #   - jq (for parsing Coralogix API response).
 #   - Environment variables (or export before running):
-#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.coralogix.com
+#     - OTEL_ENDPOINT (required) – OTLP endpoint URL, e.g. https://ingress.eu1.coralogix.com
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
@@ -34,7 +34,7 @@ TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobViaEventGrid/ARM/BlobViaEventGrid.json"
 
 # Required
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 # For Step 4 verification

--- a/DiagnosticData/ARM/DiagnosticData.json
+++ b/DiagnosticData/ARM/DiagnosticData.json
@@ -4,8 +4,16 @@
   "parameters": {
     "CoralogixRegion": {
       "type": "string",
-      "defaultValue": "Europe(eu-west-1)",
+      "defaultValue": "EU1",
       "allowedValues": [
+        "EU1",
+        "EU2",
+        "US1",
+        "US2",
+        "US3",
+        "AP1",
+        "AP2",
+        "AP3",
         "Europe(eu-west-1)",
         "US(us-east-2)",
         "US2(us-west-2)",
@@ -15,7 +23,7 @@
         "Custom"
       ],
       "metadata": {
-        "description": "The region of the Coralogix account."
+        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), US3 (Iowa), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta). The legacy region names are still accepted and map to the same endpoints."
       }
     },
     "CustomURL": {
@@ -80,7 +88,8 @@
     }
   },
   "variables": {
-    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'https://ingress.coralogix.com/azure/events/v1', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'https://ingress.coralogix.us/azure/events/v1', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'https://ingress.cx498.coralogix.com/azure/events/v1', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'https://ingress.eu2.coralogix.com/azure/events/v1', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'https://ingress.coralogix.in/azure/events/v1', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'https://ingress.coralogixsg.com/azure/events/v1', 'NULL')))))))]",
+    "CoralogixRegionCode": "[if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'EU1', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'US1', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'US2', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'EU2', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'AP1', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'AP2', parameters('CoralogixRegion')))))))]",
+    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(variables('CoralogixRegionCode'), 'EU1'), 'https://ingress.eu1.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'EU2'), 'https://ingress.eu2.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'US1'), 'https://ingress.us1.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'US2'), 'https://ingress.us2.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'US3'), 'https://ingress.us3.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'AP1'), 'https://ingress.ap1.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'AP2'), 'https://ingress.ap2.coralogix.com/azure/events/v1', if(equals(variables('CoralogixRegionCode'), 'AP3'), 'https://ingress.ap3.coralogix.com/azure/events/v1', 'NULL')))))))))]",
     "functionAppName": "[format('DiagnosticData-{0}', uniqueString(concat(resourceGroup().id, parameters('EventhubNamespace'), parameters('EventhubInstanceName'))))]",
     "hostingPlanName": "[variables('functionAppName')]",
     "applicationInsightsName": "[variables('functionAppName')]",

--- a/DiagnosticData/CHANGELOG.md
+++ b/DiagnosticData/CHANGELOG.md
@@ -5,6 +5,13 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 2.1.0 / 11 Aug 2026
+[Update] Migrate legacy Coralogix domains to the regional domains
+* `CoralogixRegion` now accepts the region codes `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`
+* The legacy region names (`Europe(eu-west-1)`, `US(us-east-2)`, `US2(us-west-2)`, `Europe2(eu-north-1)`, `India(ap-south-1)`, `Singapore(ap-southeast-1)`) are still accepted and map to the same endpoints
+* Endpoints now use `ingress.<region>.coralogix.com`; default region is `EU1`
+* The hardcoded `CORALOGIX_URL` fallback now points at `ingress.eu1.coralogix.com` (same cluster as before)
+
 ### 2.0.3 / 6 Aug 2025
 [Update] Fix module compatibility
 

--- a/DiagnosticData/DiagnosticData/index.ts
+++ b/DiagnosticData/DiagnosticData/index.ts
@@ -20,7 +20,7 @@ import { AzureFunction, Context } from "@azure/functions";
 const eventHubTrigger: AzureFunction = async function (context: Context, eventHubMessages: any): Promise<void> {
     context.log(`JavaScript eventhub trigger function called for message array ${eventHubMessages}`);
 
-    const url = process.env.CORALOGIX_URL || 'https://ingress.coralogix.com/azure/events/v1'
+    const url = process.env.CORALOGIX_URL || 'https://ingress.eu1.coralogix.com/azure/events/v1'
     const key = process.env.CORALOGIX_PRIVATE_KEY || "INVALID_KEY"
     const applicationName = process.env.CORALOGIX_APP_NAME || "NO_APPLICATION"
     const subsystemName = process.env.CORALOGIX_SUB_SYSTEM || "NO_SUBSYSTEM"

--- a/DiagnosticData/Makefile
+++ b/DiagnosticData/Makefile
@@ -5,14 +5,17 @@ export CORALOGIX_APP_NAME ?= Azure
 export CORALOGIX_SUB_SYSTEM ?= EventHub
 export NEWLINE_PATTERN ?= (?:\r\n|\r|\n)
 
-#  Cluster	                API Endpoint
-#  .com	                    https://api.coralogix.com:443/api/v1/logs
-#  .us	                    https://api.coralogix.us:443/api/v1/logs
-#  .in	                    https://api.app.coralogix.in:443/api/v1/logs
-#  .app.eu2.coralogix.com	https://api.eu2.coralogix.com:443/api/v1/logs
-#  .app.coralogixsg.com	    https://api.coralogixsg.com:443/api/v1/logs
+#  Region	Endpoint
+#  EU1	https://api.eu1.coralogix.com:443/api/v1/logs
+#  EU2	https://api.eu2.coralogix.com:443/api/v1/logs
+#  US1	https://api.us1.coralogix.com:443/api/v1/logs
+#  US2	https://api.us2.coralogix.com:443/api/v1/logs
+#  US3	https://api.us3.coralogix.com:443/api/v1/logs
+#  AP1	https://api.ap1.coralogix.com:443/api/v1/logs
+#  AP2	https://api.ap2.coralogix.com:443/api/v1/logs
+#  AP3	https://api.ap3.coralogix.com:443/api/v1/logs
 
-export CORALOGIX_URL ?= "https://api.coralogix.com:443/api/v1/logs"
+export CORALOGIX_URL ?= "https://api.eu1.coralogix.com:443/api/v1/logs"
 
 # Fixed exports
 

--- a/DiagnosticData/README.md
+++ b/DiagnosticData/README.md
@@ -26,7 +26,7 @@ The Diagnostic Data integration can also be deployed using our Terraform module 
 
 **Resource Group** - The Resource Group into which you wish to deploy the integration.
 
-**Coralogix Region** - The region of the Coralogix account.
+**Coralogix Region** - The region of the Coralogix account (EU1, EU2, US1, US2, US3, AP1, AP2, AP3, or Custom). The legacy region names are still accepted and map to the same endpoints. For more details see [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/).
 
 **Coralogix Private Key** – Can be found in your Coralogix account under Settings -> Send your logs. It is located in the upper left corner.
 

--- a/DiagnosticData/package.json
+++ b/DiagnosticData/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -17,7 +17,7 @@
 #   - Terraform >= 1.7.4.
 #   - jq (for parsing Coralogix API response).
 #   - Environment variables (or export before running):
-#     - OTEL_ENDPOINT (required) – OTLP/ingress endpoint URL, e.g. https://ingress.coralogix.com
+#     - OTEL_ENDPOINT (required) – OTLP/ingress endpoint URL, e.g. https://ingress.eu1.coralogix.com
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 (Data Usage API read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
@@ -38,7 +38,7 @@ ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-se
 NUM_BLOBS="${NUM_BLOBS:-8}"
 
 # Required
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 # For Step 4 verification

--- a/DiagnosticData/tsconfig.json
+++ b/DiagnosticData/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "module": "commonjs",
     "target": "es6",
     "outDir": "dist",

--- a/EventHub/ARM/EventHub.json
+++ b/EventHub/ARM/EventHub.json
@@ -4,8 +4,16 @@
   "parameters": {
     "CoralogixRegion": {
       "type": "string",
-      "defaultValue": "Europe(eu-west-1)",
+      "defaultValue": "EU1",
       "allowedValues": [
+        "EU1",
+        "EU2",
+        "US1",
+        "US2",
+        "US3",
+        "AP1",
+        "AP2",
+        "AP3",
         "Europe(eu-west-1)",
         "US(us-east-2)",
         "US2(us-west-2)",
@@ -15,7 +23,7 @@
         "Custom"
       ],
       "metadata": {
-        "description": "The region of the Coralogix account."
+        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), US3 (Iowa), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta). The legacy region names are still accepted and map to the same endpoints."
       }
     },
     "CustomURL": {
@@ -80,7 +88,8 @@
     }
   },
   "variables": {
-    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'https://ingress.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'https://ingress.coralogix.us/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'https://ingress.cx498.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'https://ingress.eu2.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'https://ingress.coralogix.in/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'https://ingress.coralogixsg.com/api/v1/logs', 'NULL')))))))]",
+    "CoralogixRegionCode": "[if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'EU1', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'US1', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'US2', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'EU2', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'AP1', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'AP2', parameters('CoralogixRegion')))))))]",
+    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(variables('CoralogixRegionCode'), 'EU1'), 'https://ingress.eu1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'EU2'), 'https://ingress.eu2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US1'), 'https://ingress.us1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US2'), 'https://ingress.us2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US3'), 'https://ingress.us3.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP1'), 'https://ingress.ap1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP2'), 'https://ingress.ap2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP3'), 'https://ingress.ap3.coralogix.com/api/v1/logs', 'NULL')))))))))]",
     "functionAppName": "[format('EventHub-{0}', uniqueString(concat(resourceGroup().id, parameters('EventhubNamespace'), parameters('EventhubInstanceName'))))]",
     "hostingPlanName": "[variables('functionAppName')]",
     "applicationInsightsName": "[variables('functionAppName')]",

--- a/EventHub/ARM/EventHubV2.json
+++ b/EventHub/ARM/EventHubV2.json
@@ -10,13 +10,14 @@
         "EU2",
         "US1",
         "US2",
+        "US3",
         "AP1",
         "AP2",
         "AP3",
         "Custom"
       ],
       "metadata": {
-        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta)."
+        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), US3 (Iowa), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta)."
       }
     },
     "CustomURL": {
@@ -130,13 +131,13 @@
     }
   },
   "variables": {
-    "CoralogixOtlpEndpoint": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'EU1'), 'ingress.eu1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'EU2'), 'ingress.eu2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US1'), 'ingress.us1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US2'), 'ingress.us2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP1'), 'ingress.ap1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP2'), 'ingress.ap2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP3'), 'ingress.ap3.coralogix.com:443', 'NULL'))))))))]",
+    "CoralogixOtlpEndpoint": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'EU1'), 'ingress.eu1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'EU2'), 'ingress.eu2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US1'), 'ingress.us1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US2'), 'ingress.us2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'US3'), 'ingress.us3.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP1'), 'ingress.ap1.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP2'), 'ingress.ap2.coralogix.com:443', if(equals(parameters('CoralogixRegion'), 'AP3'), 'ingress.ap3.coralogix.com:443', 'NULL')))))))))]",
     "functionAppName": "[parameters('functionAppName')]",
     "hostingPlanName": "[variables('functionAppName')]",
     "applicationInsightsName": "[variables('functionAppName')]",
     "storageAccountName": "[format('azfunctions{0}', uniqueString(resourceGroup().id))]",
     "location": "[resourceGroup().location]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.8.3/EventHub-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/EventHub-v3.9.0/EventHub-FunctionApp.zip",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', 'EP1')]"
   },
   "resources": [

--- a/EventHub/CHANGELOG.md
+++ b/EventHub/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.9.0 / 11 Aug 2026
+[FEATURE] Add the `US3` Coralogix region
+* `CoralogixRegion` now accepts `US3`, mapped to `ingress.us3.coralogix.com:443`
+* `EventHub/ARM/EventHub.json` (legacy v1 template) additionally accepts the region codes `EU1`-`AP3` alongside its existing legacy region names, and now resolves to `ingress.<region>.coralogix.com`
+
 ### 3.8.3 / 20 Jul 2026
 [FIX] Upgrade OpenTelemetry dependencies for CVE-2026-54285
 

--- a/EventHub/Makefile
+++ b/EventHub/Makefile
@@ -5,14 +5,17 @@ export CORALOGIX_APP_NAME ?= Azure
 export CORALOGIX_SUB_SYSTEM ?= EventHub
 export NEWLINE_PATTERN ?= (?:\r\n|\r|\n)
 
-#  Cluster	                API Endpoint
-#  .com	                    https://api.coralogix.com:443/api/v1/logs
-#  .us	                    https://api.coralogix.us:443/api/v1/logs
-#  .in	                    https://api.app.coralogix.in:443/api/v1/logs
-#  .app.eu2.coralogix.com	https://api.eu2.coralogix.com:443/api/v1/logs
-#  .app.coralogixsg.com	    https://api.coralogixsg.com:443/api/v1/logs
+#  Region	Endpoint
+#  EU1	https://api.eu1.coralogix.com:443/api/v1/logs
+#  EU2	https://api.eu2.coralogix.com:443/api/v1/logs
+#  US1	https://api.us1.coralogix.com:443/api/v1/logs
+#  US2	https://api.us2.coralogix.com:443/api/v1/logs
+#  US3	https://api.us3.coralogix.com:443/api/v1/logs
+#  AP1	https://api.ap1.coralogix.com:443/api/v1/logs
+#  AP2	https://api.ap2.coralogix.com:443/api/v1/logs
+#  AP3	https://api.ap3.coralogix.com:443/api/v1/logs
 
-export CORALOGIX_URL ?= "https://api.coralogix.com:443/api/v1/logs"
+export CORALOGIX_URL ?= "https://api.eu1.coralogix.com:443/api/v1/logs"
 
 # Fixed exports
 

--- a/EventHub/README.md
+++ b/EventHub/README.md
@@ -26,7 +26,7 @@ Deploy the EventHub integration by clicking the button below and signing into yo
 
 **Resource Group** - The Resource Group into which you wish to deploy the integration.
 
-**Coralogix Region** - The region of the Coralogix account (EU1, EU2, US1, US2, AP1, AP2, AP3, or Custom). For more details see [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/).
+**Coralogix Region** - The region of the Coralogix account (EU1, EU2, US1, US2, US3, AP1, AP2, AP3, or Custom). For more details see [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/).
 
 **Custom URL** - Your Custom URL for the Coralogix account. Only required if you selected 'Custom' as the Coralogix Region.
 

--- a/EventHub/package.json
+++ b/EventHub/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "3.8.3",
+  "version": "3.9.0",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",
   "license": "Apache-2.0",

--- a/StorageQueue/ARM/StorageQueue.json
+++ b/StorageQueue/ARM/StorageQueue.json
@@ -4,8 +4,16 @@
   "parameters": {
     "CoralogixRegion": {
       "type": "string",
-      "defaultValue": "Europe(eu-west-1)",
+      "defaultValue": "EU1",
       "allowedValues": [
+        "EU1",
+        "EU2",
+        "US1",
+        "US2",
+        "US3",
+        "AP1",
+        "AP2",
+        "AP3",
         "Europe(eu-west-1)",
         "US(us-east-2)",
         "US2(us-west-2)",
@@ -15,7 +23,7 @@
         "Custom"
       ],
       "metadata": {
-        "description": "The region of the Coralogix account."
+        "description": "The Coralogix region: EU1 (Ireland), EU2 (Stockholm), US1 (Ohio), US2 (Oregon), US3 (Iowa), AP1 (Mumbai), AP2 (Singapore), AP3 (Jakarta). The legacy region names are still accepted and map to the same endpoints."
       }
     },
     "CustomURL": {
@@ -74,7 +82,8 @@
     }
   },
   "variables": {
-    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'https://ingress.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'https://ingress.coralogix.us/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'https://ingress.cx498.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'https://ingress.eu2.coralogix.com/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'https://ingress.coralogix.in/api/v1/logs', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'https://ingress.coralogixsg.com/api/v1/logs', 'NULL')))))))]",
+    "CoralogixRegionCode": "[if(equals(parameters('CoralogixRegion'), 'Europe(eu-west-1)'), 'EU1', if(equals(parameters('CoralogixRegion'), 'US(us-east-2)'), 'US1', if(equals(parameters('CoralogixRegion'), 'US2(us-west-2)'), 'US2', if(equals(parameters('CoralogixRegion'), 'Europe2(eu-north-1)'), 'EU2', if(equals(parameters('CoralogixRegion'), 'India(ap-south-1)'), 'AP1', if(equals(parameters('CoralogixRegion'), 'Singapore(ap-southeast-1)'), 'AP2', parameters('CoralogixRegion')))))))]",
+    "CoralogixURL": "[if(equals(parameters('CoralogixRegion'), 'Custom'), parameters('CustomURL'), if(equals(variables('CoralogixRegionCode'), 'EU1'), 'https://ingress.eu1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'EU2'), 'https://ingress.eu2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US1'), 'https://ingress.us1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US2'), 'https://ingress.us2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'US3'), 'https://ingress.us3.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP1'), 'https://ingress.ap1.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP2'), 'https://ingress.ap2.coralogix.com/api/v1/logs', if(equals(variables('CoralogixRegionCode'), 'AP3'), 'https://ingress.ap3.coralogix.com/api/v1/logs', 'NULL')))))))))]",
     "functionAppName": "[format('StorageQueue-{0}', uniqueString(concat(resourceGroup().id, parameters('StorageAccountName'), parameters('StorageQueueName'))))]",
     "hostingPlanName": "[variables('functionAppName')]",
     "applicationInsightsName": "[variables('functionAppName')]",

--- a/StorageQueue/CHANGELOG.md
+++ b/StorageQueue/CHANGELOG.md
@@ -5,6 +5,12 @@
 <!-- ### version / full date -->
 <!-- * [Update/Bug fix] message that describes the changes that you apply -->
 
+### 2.1.0 / 11 Aug 2026
+[Update] Migrate legacy Coralogix domains to the regional domains
+* `CoralogixRegion` now accepts the region codes `EU1`, `EU2`, `US1`, `US2`, `US3`, `AP1`, `AP2`, `AP3`
+* The legacy region names (`Europe(eu-west-1)`, `US(us-east-2)`, `US2(us-west-2)`, `Europe2(eu-north-1)`, `India(ap-south-1)`, `Singapore(ap-southeast-1)`) are still accepted and map to the same endpoints
+* Endpoints now use `ingress.<region>.coralogix.com`; default region is `EU1`
+
 ### 2.0.3 / 19 Feb 2026
 [Bug] Fix the package type from `module` to `commonjs`
 [Bug] Update ARM template (parameter case matching)

--- a/StorageQueue/Makefile
+++ b/StorageQueue/Makefile
@@ -4,14 +4,17 @@ export AZURE_REGION ?= westeurope
 export CORALOGIX_APP_NAME ?= Azure
 export CORALOGIX_SUB_SYSTEM ?= StorageQueue
 
-#  Cluster	                API Endpoint
-#  .com	                    https://api.coralogix.com:443/api/v1/logs
-#  .us	                    https://api.coralogix.us:443/api/v1/logs
-#  .in	                    https://api.app.coralogix.in:443/api/v1/logs
-#  .app.eu2.coralogix.com	https://api.eu2.coralogix.com:443/api/v1/logs
-#  .app.coralogixsg.com	    https://api.coralogixsg.com:443/api/v1/logs
+#  Region	Endpoint
+#  EU1	https://api.eu1.coralogix.com:443/api/v1/logs
+#  EU2	https://api.eu2.coralogix.com:443/api/v1/logs
+#  US1	https://api.us1.coralogix.com:443/api/v1/logs
+#  US2	https://api.us2.coralogix.com:443/api/v1/logs
+#  US3	https://api.us3.coralogix.com:443/api/v1/logs
+#  AP1	https://api.ap1.coralogix.com:443/api/v1/logs
+#  AP2	https://api.ap2.coralogix.com:443/api/v1/logs
+#  AP3	https://api.ap3.coralogix.com:443/api/v1/logs
 
-export CORALOGIX_URL ?= "https://api.coralogix.com:443/api/v1/logs"
+export CORALOGIX_URL ?= "https://api.eu1.coralogix.com:443/api/v1/logs"
 
 # Fixed exports
 

--- a/StorageQueue/README.md
+++ b/StorageQueue/README.md
@@ -20,7 +20,7 @@ The Storage Queue integration can be deployed by clicking the link below and sig
 
 **Resource Group** - The Resource Group into which you wish to deploy the integration.
 
-**Coralogix Region** - The region of the Coralogix account.
+**Coralogix Region** - The region of the Coralogix account (EU1, EU2, US1, US2, US3, AP1, AP2, AP3, or Custom). The legacy region names are still accepted and map to the same endpoints. For more details see [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/).
 
 **Coralogix Private Key** – Can be found in your Coralogix account under Settings -> Send your logs. It is located in the upper left corner.
 

--- a/StorageQueue/package.json
+++ b/StorageQueue/package.json
@@ -1,7 +1,7 @@
 {
   "name": "coralogix-azure-serverless",
   "title": "Azure Functions for integration with Coralogix",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "type": "commonjs",
   "description": "Azure Functions Set for integration with Coralogix",
   "homepage": "https://coralogix.com",

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -15,7 +15,7 @@
 #   - Terraform >= 1.7.4.
 #   - jq (for parsing Coralogix API response).
 #   - Environment variables (or export before running):
-#     - OTEL_ENDPOINT (required) – Coralogix ingress base URL, e.g. https://ingress.coralogix.com
+#     - OTEL_ENDPOINT (required) – Coralogix ingress base URL, e.g. https://ingress.eu1.coralogix.com
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
@@ -33,7 +33,7 @@ TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
 ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/StorageQueue/ARM/StorageQueue.json"
 
 # Required
-: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
+: "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
 : "${CORALOGIX_API_KEY:?Set CORALOGIX_API_KEY (Send your data / Private key for the function)}"
 
 # For Step 4 verification

--- a/StorageQueue/tsconfig.json
+++ b/StorageQueue/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "types": ["node"],
     "module": "commonjs",
     "target": "es6",
     "outDir": "dist",


### PR DESCRIPTION
# Description

Migrates every legacy Coralogix domain in this repo to the current regional domains, and adds the **US3** region (GCP `us-central1`), which was missing everywhere.

| Legacy | New |
|---|---|
| `coralogix.com` | `eu1.coralogix.com` |
| `coralogix.us` | `us1.coralogix.com` |
| `cx498.coralogix.com` | `us2.coralogix.com` |
| `coralogix.in` | `ap1.coralogix.com` |
| `coralogixsg.com` | `ap2.coralogix.com` |

Regions verified against [Account Settings / Coralogix Domains](https://coralogix.com/docs/user-guides/account-management/account-settings/coralogix-domain/): `EU1 EU2 US1 US2 US3 AP1 AP2 AP3`.

### ARM templates

`BlobViaEventGrid`, `DiagnosticData`, `EventHub/ARM/EventHub.json`, `StorageQueue` — `CoralogixRegion` now accepts the 8 region codes **in addition to** the 6 legacy names. A new `CoralogixRegionCode` variable normalises legacy names onto codes, and the endpoint chain maps codes to `ingress.<code>.coralogix.com`.

`EventHub/ARM/EventHubV2.json` — adds `US3` only. Its legacy region names were removed on purpose in v3.0.0 as a documented BREAKING change, so they are **not** reinstated here.

### Other

- Makefiles: the stale 5-row cluster tables are replaced with the canonical 8-region list; `CORALOGIX_URL` defaults migrated (BlobViaEventGrid keeps pointing at Singapore, now `AP2`, matching its `southeastasia` Azure region).
- READMEs: all four now document the same canonical region list.
- e2e scripts / test docs: legacy example endpoints migrated to `ingress.eu1.coralogix.com`.
- `DiagnosticData/DiagnosticData/index.ts`: the hardcoded `CORALOGIX_URL` fallback now points at `ingress.eu1.coralogix.com` — the same cluster as before, and only reachable when the env var is unset (the ARM template always sets it).

## Compatibility guarantee

**No accepted input value was removed or renamed.** Every legacy `CoralogixRegion` value still deploys and resolves to the same cluster it did before:

| Legacy value | Resolves to |
|---|---|
| `Europe(eu-west-1)` | `ingress.eu1.coralogix.com` |
| `US(us-east-2)` | `ingress.us1.coralogix.com` |
| `US2(us-west-2)` | `ingress.us2.coralogix.com` |
| `Europe2(eu-north-1)` | `ingress.eu2.coralogix.com` |
| `India(ap-south-1)` | `ingress.ap1.coralogix.com` |
| `Singapore(ap-southeast-1)` | `ingress.ap2.coralogix.com` |
| `Custom` | `CustomURL` (unchanged) |

Existing deployments and saved parameter files keep working untouched.

**One user-visible default changed:** `defaultValue` for `CoralogixRegion` moved from `Europe(eu-west-1)` to `EU1` in the four legacy templates. Both resolve to the same endpoint after this change, and it matches `EventHubV2`'s existing default. Easy to revert if unwanted.

# How Has This Been Tested?

1. **Repo-wide grep** — zero legacy domain occurrences remain (`git grep -IE 'coralogix\.us|coralogix\.in|coralogixsg|cx498|(ingress|api)\.coralogix\.com'`), with no exceptions.
2. **Functional proof of the mapping** — the real `if(equals(...))` expressions were parsed out of the templates and interpreted for all 15 accepted values across all 5 templates: 68/68 resolve to the expected regional endpoint, `:443` is preserved everywhere it existed, no value falls through to `NULL`, and no value maps to a legacy domain.
3. **Accepted-value diff vs `master`** — zero removals from any `allowedValues`; every `defaultValue` is a member of its `allowedValues`; every region code that maps to an endpoint is accepted, and every accepted value maps.
4. **CI's own commands** — `npm run test` + `npm run build` (release.yaml) and `build:production` (build.yaml) pass for all five packages. EventHub: 104/104 tests.
5. **DNS** — all 8 `ingress.*` and `api.*` regional hosts resolve, including `us3` (GCP address range, consistent with GCP `us-central1`). All 5 legacy hosts still resolve, so keeping them accepted is genuinely non-breaking.

Not run locally: `e2e.yaml` (needs live Azure OIDC and Coralogix secrets) and a real `az deployment` (needs a subscription).

### Mapped by inference

- `US3` appears nowhere in the repo — its endpoint was derived from the docs' region code and confirmed by DNS.
- The Makefile comments listed `api.app.coralogix.in`; the stray `app.` looks like a typo and was mapped to `api.ap1.coralogix.com`.

## Bundled fix (separable)

`DiagnosticData` and `StorageQueue` fail `tsc` on `master` today: `typescript` is unpinned (`">=4.9.4"`) and now resolves to 6.x, which no longer auto-includes `@types/*`. Packages on `@azure/functions` v4 pick up node types transitively; these two are on v3 and do not. Since this PR puts both packages into build.yaml's matrix, the failure would surface here, so `"types": ["node"]` was added to their `tsconfig.json`. The durable fix is pinning `typescript`.

## Pre-existing issues found, not fixed here

- `DiagnosticData`'s Makefile `CORALOGIX_URL` default uses `api.<...>/api/v1/logs`, but the function's actual endpoint is `ingress.<...>/azure/events/v1`. Only the domain was migrated; the wrong prefix and path were left verbatim.
- `BlobToOtel`'s `packageUri` pointed at `BlobToOtel-v3.0.2`, a release that was never published (tags go 3.0.1 → 3.1.0) while `package.json` said 3.0.2. The 3.2.0 bump in this PR incidentally repairs that broken Deploy-to-Azure button.
- `.release_version` files are stale (EventHub `2.1.0`, BlobToOtel `2.6.0`); they are written in CI and never committed back.

# Checklist:
- [x] I have updated the version in the relevant file.
- [x] I have updated the relevant component changelog(s)
- [ ] This change does not affect any particular component (e.g. it's readme or docs change)

**Versions:** EventHub `3.9.0`, BlobToOtel `3.2.0`, BlobViaEventGrid `2.2.0`, DiagnosticData `2.1.0`, StorageQueue `2.1.0`.

> `EventHub-v3.9.0` and `BlobToOtel-v3.2.0` are what semantic-release is expected to compute from this `feat` commit (EventHub's last tag is 3.8.3 and is HEAD; BlobToOtel's is 3.1.0). If it lands on different numbers, the two `packageUri` values need correcting before merge.
