### PR TITLE
ci(e2e): make the e2e suite runnable and green for all five packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,7 @@ jobs:
         with:
           files_ignore: |
             **/*.md
+            **/tests/**
             .github/**
             .gitignore
             AUTHORS.md

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,20 +1,21 @@
 name: E2E Tests
 
 on:
-  # Both build workflows publish the artifact the ARM templates deploy from, so
-  # e2e must always run *after* one of them, never alongside. On a plain `push`
-  # trigger the three S3-backed packages would race the zip upload and test
-  # whichever artifact happened to be in the bucket at that moment.
-  #   "Build, Test & Release" (release.yaml) -> EventHub, BlobToOtel
-  #   "Build & Release"       (build.yaml)   -> BlobViaEventGrid, DiagnosticData, StorageQueue
-  workflow_run:
-    workflows:
-      - "Build, Test & Release"
-      - "Build & Release"
-    branches:
-      - master
-    types:
-      - completed
+  # Called by "Build, Test & Release" once it knows which packages it built.
+  # That workflow already computes the package list, so e2e is told what to test
+  # rather than inferring it -- an earlier version keyed off the name of the
+  # upstream workflow, which silently stopped covering three packages the moment
+  # the two build workflows were merged into one.
+  workflow_call:
+    inputs:
+      packages:
+        description: "JSON array of package names to test"
+        required: true
+        type: string
+      ref:
+        description: "Commit to test, and the ref the ARM templates are fetched from"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       package:
@@ -44,8 +45,6 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
-    # For workflow_run: only proceed if the upstream build/release succeeded.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
       has-changes: ${{ steps.set-packages.outputs.has-changes }}
@@ -54,39 +53,22 @@ jobs:
         id: set-packages
         env:
           EVENT: ${{ github.event_name }}
-          UPSTREAM: ${{ github.event.workflow_run.name }}
+          CALLER_PACKAGES: ${{ inputs.packages }}
           INPUT_PACKAGE: ${{ github.event.inputs.package }}
         run: |
           set -euo pipefail
 
-          # Which packages the upstream workflow is responsible for publishing.
-          # Each package's artifact is republished by exactly one of the two, so
-          # e2e only tests packages whose artifact the finished run could have
-          # changed. Both sets are fixed rather than path-filtered: these runs are
-          # infrequent, and a stale filter that skips a package is worse than
-          # occasionally testing one that did not change.
-          case "$EVENT" in
-            workflow_run)
-              case "$UPSTREAM" in
-                "Build, Test & Release") packages='["EventHub","BlobToOtel"]' ;;
-                "Build & Release")       packages='["BlobViaEventGrid","DiagnosticData","StorageQueue"]' ;;
-                *)
-                  echo "Unrecognised upstream workflow: '$UPSTREAM'" >&2
-                  exit 1
-                  ;;
-              esac
-              ;;
-            workflow_dispatch)
-              if [[ -n "${INPUT_PACKAGE:-}" && "$INPUT_PACKAGE" != "all" ]]; then
-                packages="[\"$INPUT_PACKAGE\"]"
-              else
-                packages='["EventHub","BlobToOtel","BlobViaEventGrid","DiagnosticData","StorageQueue"]'
-              fi
-              ;;
-            *)
-              packages='[]'
-              ;;
-          esac
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            # Manual runs test one package, or all of them.
+            if [[ -n "${INPUT_PACKAGE:-}" && "$INPUT_PACKAGE" != "all" ]]; then
+              packages="[\"$INPUT_PACKAGE\"]"
+            else
+              packages='["EventHub","BlobToOtel","BlobViaEventGrid","DiagnosticData","StorageQueue"]'
+            fi
+          else
+            # Called: test exactly what the caller built.
+            packages="${CALLER_PACKAGES:-[]}"
+          fi
 
           echo "packages=$packages" >> "$GITHUB_OUTPUT"
           if [[ "$packages" == "[]" ]]; then
@@ -109,14 +91,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
-          # workflow_run checks out the default branch by default; pin to the
-          # commit that triggered the release so we test that exact code.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # Test the commit the caller built, not whatever master is now.
+          ref: ${{ inputs.ref || github.sha }}
 
       - name: Resolve template ref
         id: ref
         env:
-          REF: ${{ github.event.workflow_run.head_sha || github.sha }}
+          REF: ${{ inputs.ref || github.sha }}
         run: echo "sha=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,22 +1,20 @@
 name: E2E Tests
 
 on:
+  # Both build workflows publish the artifact the ARM templates deploy from, so
+  # e2e must always run *after* one of them, never alongside. On a plain `push`
+  # trigger the three S3-backed packages would race the zip upload and test
+  # whichever artifact happened to be in the bucket at that moment.
+  #   "Build, Test & Release" (release.yaml) -> EventHub, BlobToOtel
+  #   "Build & Release"       (build.yaml)   -> BlobViaEventGrid, DiagnosticData, StorageQueue
   workflow_run:
     workflows:
       - "Build, Test & Release"
+      - "Build & Release"
     branches:
       - master
     types:
       - completed
-  # EventHub/BlobToOtel arrive via workflow_run above (after their release publishes).
-  # The other three have no release workflow, so they need their own push trigger.
-  push:
-    branches:
-      - master
-    paths:
-      - "BlobViaEventGrid/**"
-      - "DiagnosticData/**"
-      - "StorageQueue/**"
   workflow_dispatch:
     inputs:
       package:
@@ -46,66 +44,57 @@ permissions:
 jobs:
   detect-changes:
     runs-on: ubuntu-latest
-    # For workflow_run: only proceed if the release workflow succeeded
+    # For workflow_run: only proceed if the upstream build/release succeeded.
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     outputs:
       packages: ${{ steps.set-packages.outputs.packages }}
       has-changes: ${{ steps.set-packages.outputs.has-changes }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Detect changed packages
-        uses: dorny/paths-filter@v3
-        id: changes
-        if: github.event_name == 'push'
-        with:
-          base: ${{ github.event.before }}
-          filters: |
-            StorageQueue:
-              - 'StorageQueue/**'
-            EventHub:
-              - 'EventHub/**'
-            DiagnosticData:
-              - 'DiagnosticData/**'
-            BlobViaEventGrid:
-              - 'BlobViaEventGrid/**'
-            BlobToOtel:
-              - 'BlobToOtel/**'
-
       - name: Set packages matrix
         id: set-packages
         env:
           EVENT: ${{ github.event_name }}
-          SQ: ${{ steps.changes.outputs.StorageQueue }}
-          EH: ${{ steps.changes.outputs.EventHub }}
-          DD: ${{ steps.changes.outputs.DiagnosticData }}
-          BVE: ${{ steps.changes.outputs.BlobViaEventGrid }}
-          BTO: ${{ steps.changes.outputs.BlobToOtel }}
+          UPSTREAM: ${{ github.event.workflow_run.name }}
           INPUT_PACKAGE: ${{ github.event.inputs.package }}
         run: |
-          if [[ "$EVENT" == "push" && ("$SQ" == "true" || "$EH" == "true" || "$DD" == "true" || "$BVE" == "true" || "$BTO" == "true") ]]; then
-            packages=()
-            [[ "$SQ" == "true" ]] && packages+=("StorageQueue")
-            [[ "$EH" == "true" ]] && packages+=("EventHub")
-            [[ "$DD" == "true" ]] && packages+=("DiagnosticData")
-            [[ "$BVE" == "true" ]] && packages+=("BlobViaEventGrid")
-            [[ "$BTO" == "true" ]] && packages+=("BlobToOtel")
-            pk_json=$(printf '%s\n' "${packages[@]}" | jq -R . | jq -s -c .)
-            echo "packages=$pk_json" >> $GITHUB_OUTPUT
-            echo "has-changes=true" >> $GITHUB_OUTPUT
-          elif [[ "$EVENT" == "workflow_dispatch" && -n "${INPUT_PACKAGE:-}" && "$INPUT_PACKAGE" != "all" ]]; then
-            echo "packages=[\"$INPUT_PACKAGE\"]" >> $GITHUB_OUTPUT
-            echo "has-changes=true" >> $GITHUB_OUTPUT
-          elif [[ "$EVENT" == "workflow_dispatch" || "$EVENT" == "workflow_run" ]]; then
-            echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
-            echo 'has-changes=true' >> $GITHUB_OUTPUT
+          set -euo pipefail
+
+          # Which packages the upstream workflow is responsible for publishing.
+          # Each package's artifact is republished by exactly one of the two, so
+          # e2e only tests packages whose artifact the finished run could have
+          # changed. Both sets are fixed rather than path-filtered: these runs are
+          # infrequent, and a stale filter that skips a package is worse than
+          # occasionally testing one that did not change.
+          case "$EVENT" in
+            workflow_run)
+              case "$UPSTREAM" in
+                "Build, Test & Release") packages='["EventHub","BlobToOtel"]' ;;
+                "Build & Release")       packages='["BlobViaEventGrid","DiagnosticData","StorageQueue"]' ;;
+                *)
+                  echo "Unrecognised upstream workflow: '$UPSTREAM'" >&2
+                  exit 1
+                  ;;
+              esac
+              ;;
+            workflow_dispatch)
+              if [[ -n "${INPUT_PACKAGE:-}" && "$INPUT_PACKAGE" != "all" ]]; then
+                packages="[\"$INPUT_PACKAGE\"]"
+              else
+                packages='["EventHub","BlobToOtel","BlobViaEventGrid","DiagnosticData","StorageQueue"]'
+              fi
+              ;;
+            *)
+              packages='[]'
+              ;;
+          esac
+
+          echo "packages=$packages" >> "$GITHUB_OUTPUT"
+          if [[ "$packages" == "[]" ]]; then
+            echo "has-changes=false" >> "$GITHUB_OUTPUT"
           else
-            echo 'packages=[]' >> $GITHUB_OUTPUT
-            echo 'has-changes=false' >> $GITHUB_OUTPUT
+            echo "has-changes=true" >> "$GITHUB_OUTPUT"
           fi
+          echo "Testing: $packages"
 
   e2e:
     needs: detect-changes

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -8,6 +8,36 @@ on:
       - master
     types:
       - completed
+  # EventHub/BlobToOtel arrive via workflow_run above (after their release publishes).
+  # The other three have no release workflow, so they need their own push trigger.
+  push:
+    branches:
+      - master
+    paths:
+      - "BlobViaEventGrid/**"
+      - "DiagnosticData/**"
+      - "StorageQueue/**"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package to test (all = every package)"
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - all
+          - BlobViaEventGrid
+          - BlobToOtel
+          - DiagnosticData
+          - EventHub
+          - StorageQueue
+
+# Serialise every e2e run. The resource group names are deterministic and the
+# pre-flight sweep in e2e.sh deletes a stale group by name, so two overlapping
+# runs would tear down each other's resources mid-test.
+concurrency:
+  group: e2e-tests
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -54,6 +84,7 @@ jobs:
           DD: ${{ steps.changes.outputs.DiagnosticData }}
           BVE: ${{ steps.changes.outputs.BlobViaEventGrid }}
           BTO: ${{ steps.changes.outputs.BlobToOtel }}
+          INPUT_PACKAGE: ${{ github.event.inputs.package }}
         run: |
           if [[ "$EVENT" == "push" && ("$SQ" == "true" || "$EH" == "true" || "$DD" == "true" || "$BVE" == "true" || "$BTO" == "true") ]]; then
             packages=()
@@ -64,6 +95,9 @@ jobs:
             [[ "$BTO" == "true" ]] && packages+=("BlobToOtel")
             pk_json=$(printf '%s\n' "${packages[@]}" | jq -R . | jq -s -c .)
             echo "packages=$pk_json" >> $GITHUB_OUTPUT
+            echo "has-changes=true" >> $GITHUB_OUTPUT
+          elif [[ "$EVENT" == "workflow_dispatch" && -n "${INPUT_PACKAGE:-}" && "$INPUT_PACKAGE" != "all" ]]; then
+            echo "packages=[\"$INPUT_PACKAGE\"]" >> $GITHUB_OUTPUT
             echo "has-changes=true" >> $GITHUB_OUTPUT
           elif [[ "$EVENT" == "workflow_dispatch" || "$EVENT" == "workflow_run" ]]; then
             echo 'packages=["StorageQueue","EventHub","DiagnosticData","BlobViaEventGrid","BlobToOtel"]' >> $GITHUB_OUTPUT
@@ -85,6 +119,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # workflow_run checks out the default branch by default; pin to the
+          # commit that triggered the release so we test that exact code.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Resolve template ref
+        id: ref
+        env:
+          REF: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: echo "sha=$REF" >> "$GITHUB_OUTPUT"
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -111,4 +155,6 @@ jobs:
           CORALOGIX_API_KEY: ${{ secrets.CORALOGIX_API_KEY }}
           CORALOGIX_QUERY_API_KEY: ${{ secrets.CORALOGIX_QUERY_API_KEY }}
           CORALOGIX_DIRECT_MODE: "true"
+          # Deploy the ARM template from the commit under test, not master.
+          ARM_TEMPLATE_REF: ${{ steps.ref.outputs.sha }}
         run: ./e2e.sh

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -4,7 +4,8 @@
 #
 # Order of execution:
 #   1. Provision Azure resources with Terraform (prereqs + Event Hub consumer group).
-#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2. Deploy the ARM template at ARM_TEMPLATE_REF (default master) via Azure CLI,
+#      with explicit parameters from step 1.
 #   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (upload a blob to trigger the function).
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
@@ -58,10 +59,24 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Provision with Terraform ---
 # An aborted earlier run can leave the resource group behind, and because the
 # name is deterministic that makes every later `terraform apply` fail with
-# "already exists". Clear it first, blocking, so the run starts clean.
+# "already exists". The failure path deletes with --no-wait, so the group may
+# also still be mid-delete from that run: request deletion (ignoring an error if
+# one is already in flight) and then wait until it has actually gone, rather than
+# assuming a blocking delete can start.
+PREFLIGHT_TIMEOUT_SECS="${PREFLIGHT_TIMEOUT_SECS:-600}"
 if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
-  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
-  az group delete --name "$RG_NAME" --yes
+  log "Pre-flight: resource group $RG_NAME is left over from an earlier run; removing it..."
+  az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  waited=0
+  while [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; do
+    if [[ "$waited" -ge "$PREFLIGHT_TIMEOUT_SECS" ]]; then
+      err "Pre-flight: $RG_NAME still present after ${PREFLIGHT_TIMEOUT_SECS}s. Delete it manually and re-run."
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
 
 log "Step 1: Provisioning Azure resources with Terraform (prereqs + Event Hub consumer group)..."
@@ -80,8 +95,8 @@ STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_str
 
 log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, ConsumerGroup=$EVENTHUB_CONSUMER_GROUP"
 
-# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
-log "Step 2: Deploying ARM template from master with explicit parameters..."
+# --- Step 2: Deploy the ARM template at ARM_TEMPLATE_REF with explicit parameters ---
+log "Step 2: Deploying ARM template (ref: ${ARM_TEMPLATE_REF}) with explicit parameters..."
 PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
 # Build parameters JSON with explicit values (no defaults); escape quotes in values.
 build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -48,11 +48,22 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 # Must match the default of var.resource_group_name in tests/terraform.
 RG_NAME="${RG_NAME:-blobtootel-e2e-rg}"
 
+# Terraform state here is disposable: every run provisions from scratch into a
+# resource group whose name is fixed. Carrying it between runs is not merely
+# useless but harmful -- it pins random_string.suffix, so the "random" storage
+# account name is reused, the recreated account lands on the identical resource
+# ID, and diagnostic settings Azure orphaned when the previous group was deleted
+# resurface as "already exists". Discard it whenever the group goes away.
+discard_terraform_state() {
+  rm -f "${TERRAFORM_DIR}/terraform.tfstate" "${TERRAFORM_DIR}/terraform.tfstate.backup"
+}
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi
+  discard_terraform_state
 }
 trap cleanup_after_failure EXIT
 
@@ -78,6 +89,11 @@ if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
   done
   log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
+
+# Nothing this harness provisions survives the sweep above, so any state still on
+# disk describes resources that no longer exist -- left behind by a run that died
+# before its own cleanup. Start from an empty state unconditionally.
+discard_terraform_state
 
 log "Step 1: Provisioning Azure resources with Terraform (prereqs + Event Hub consumer group)..."
 cd "$TERRAFORM_DIR"
@@ -217,9 +233,5 @@ az group delete --name "$RG_NAME" --yes
 log "Waiting for resource group deletion..."
 while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
 # Clean Terraform state so next run can provision from scratch.
-cd "$TERRAFORM_DIR"
-while read -r state_key; do
-  [[ -z "$state_key" ]] && continue
-  terraform state rm "$state_key" 2>/dev/null || true
-done < <(terraform state list 2>/dev/null || true)
+discard_terraform_state
 log "E2E test finished."

--- a/BlobToOtel/tests/e2e.sh
+++ b/BlobToOtel/tests/e2e.sh
@@ -27,7 +27,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
-ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobToOtel/ARM/BlobToOtel.json"
+# Defaults to master so a local run needs no setup; CI overrides ARM_TEMPLATE_REF
+# with the commit under test so the template being validated is the one changed.
+ARM_TEMPLATE_REF="${ARM_TEMPLATE_REF:-master}"
+ARM_TEMPLATE_URI="${ARM_TEMPLATE_URI:-https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/${ARM_TEMPLATE_REF}/BlobToOtel/ARM/BlobToOtel.json}"
 
 # Required
 : "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
@@ -39,6 +42,11 @@ CX_APP="${CORALOGIX_APPLICATION:-azure}"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
+# Known up front (not read from terraform output) so the cleanup trap below can
+# still tear down the resource group when `terraform apply` fails part-way.
+# Must match the default of var.resource_group_name in tests/terraform.
+RG_NAME="${RG_NAME:-blobtootel-e2e-rg}"
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
@@ -48,12 +56,19 @@ cleanup_after_failure() {
 trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
+# An aborted earlier run can leave the resource group behind, and because the
+# name is deterministic that makes every later `terraform apply` fail with
+# "already exists". Clear it first, blocking, so the run starts clean.
+if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
+  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
+  az group delete --name "$RG_NAME" --yes
+fi
+
 log "Step 1: Provisioning Azure resources with Terraform (prereqs + Event Hub consumer group)..."
 cd "$TERRAFORM_DIR"
 terraform init -input=false
-terraform apply -input=false -auto-approve
+terraform apply -input=false -auto-approve -var="resource_group_name=${RG_NAME}"
 
-RG_NAME=$(terraform output -raw resource_group_name)
 STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
 STORAGE_RG=$(terraform output -raw storage_account_resource_group)
 CONTAINER_NAME=$(terraform output -raw blob_container_name)

--- a/BlobToOtel/tests/terraform/main.tf
+++ b/BlobToOtel/tests/terraform/main.tf
@@ -24,9 +24,17 @@ locals {
   location    = "westeurope"
 }
 
+# e2e.sh passes this so it knows the name before apply and can clean up a
+# partially-created group. Keep the default in sync with RG_NAME in e2e.sh.
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group holding the e2e prerequisites."
+  default     = "blobtootel-e2e-rg"
+}
+
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)
 resource "azurerm_resource_group" "e2e" {
-  name     = "${local.name_prefix}-rg"
+  name     = var.resource_group_name
   location = local.location
 }
 

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -4,7 +4,8 @@
 #
 # Order of execution:
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, container).
-#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2. Deploy the ARM template at ARM_TEMPLATE_REF (default master) via Azure CLI,
+#      with explicit parameters from step 1.
 #      The ARM template creates the Event Grid system topic and subscription to the function.
 #   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (upload a blob to trigger Event Grid → function).
@@ -69,10 +70,24 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Provision with Terraform ---
 # An aborted earlier run can leave the resource group behind, and because the
 # name is deterministic that makes every later `terraform apply` fail with
-# "already exists". Clear it first, blocking, so the run starts clean.
+# "already exists". The failure path deletes with --no-wait, so the group may
+# also still be mid-delete from that run: request deletion (ignoring an error if
+# one is already in flight) and then wait until it has actually gone, rather than
+# assuming a blocking delete can start.
+PREFLIGHT_TIMEOUT_SECS="${PREFLIGHT_TIMEOUT_SECS:-600}"
 if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
-  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
-  az group delete --name "$RG_NAME" --yes
+  log "Pre-flight: resource group $RG_NAME is left over from an earlier run; removing it..."
+  az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  waited=0
+  while [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; do
+    if [[ "$waited" -ge "$PREFLIGHT_TIMEOUT_SECS" ]]; then
+      err "Pre-flight: $RG_NAME still present after ${PREFLIGHT_TIMEOUT_SECS}s. Delete it manually and re-run."
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, container)..."
@@ -87,8 +102,8 @@ STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_str
 
 log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Container=$CONTAINER_NAME"
 
-# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
-log "Step 2: Deploying ARM template from master (function + Event Grid system topic and subscription)..."
+# --- Step 2: Deploy the ARM template at ARM_TEMPLATE_REF with explicit parameters ---
+log "Step 2: Deploying ARM template (ref: ${ARM_TEMPLATE_REF}) (function + Event Grid system topic and subscription)..."
 PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
 # Build parameters JSON; escape quotes in values.
 build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
@@ -115,26 +130,37 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
 # The template creates the Event Grid subscription in the same deployment as the
 # function app. Event Grid validates the webhook endpoint immediately, and if the
 # app has not finished pulling its package yet that probe 404s and the whole
-# deployment fails with "Webhook endpoint validation failed". Retrying is enough:
-# the app is warm by the second attempt, and the deployment is idempotent.
+# deployment fails with "Webhook endpoint validation failed". The app is warm by
+# the next attempt and the deployment is idempotent, so retry — but only for that
+# specific error. Anything else is a real template or parameter fault and must
+# surface immediately instead of being hidden behind two minutes of retries.
 ARM_DEPLOY_ATTEMPTS="${ARM_DEPLOY_ATTEMPTS:-3}"
+DEPLOY_LOG="${SCRIPT_DIR}/.arm-deploy.log"
 for attempt in $(seq 1 "$ARM_DEPLOY_ATTEMPTS"); do
   if az deployment group create \
       --resource-group "$RG_NAME" \
       --template-uri "$ARM_TEMPLATE_URI" \
-      --parameters "@${PARAMS_FILE}"; then
+      --parameters "@${PARAMS_FILE}" 2>&1 | tee "$DEPLOY_LOG"; then
     break
   fi
-  if [[ "$attempt" -eq "$ARM_DEPLOY_ATTEMPTS" ]]; then
-    err "ARM deployment failed after ${ARM_DEPLOY_ATTEMPTS} attempts."
-    rm -f "$PARAMS_FILE"
+
+  if ! grep -qE 'Webhook endpoint validation failed|StatusCode: NotFound' "$DEPLOY_LOG"; then
+    err "ARM deployment failed for a reason other than the Event Grid webhook race; not retrying (full output above)."
+    rm -f "$PARAMS_FILE" "$DEPLOY_LOG"
     exit 1
   fi
-  log "ARM deployment attempt ${attempt} failed (likely Event Grid webhook validation); retrying in 60s..."
+
+  if [[ "$attempt" -eq "$ARM_DEPLOY_ATTEMPTS" ]]; then
+    err "Event Grid webhook validation still failing after ${ARM_DEPLOY_ATTEMPTS} attempts."
+    rm -f "$PARAMS_FILE" "$DEPLOY_LOG"
+    exit 1
+  fi
+
+  log "Attempt ${attempt}: Event Grid webhook validation failed (function app not serving yet); retrying in 60s..."
   sleep 60
 done
 
-rm -f "$PARAMS_FILE"
+rm -f "$PARAMS_FILE" "$DEPLOY_LOG"
 log "ARM deployment completed."
 
 # --- Step 2c: Sync function triggers, then wait before sending data ---

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -20,6 +20,10 @@
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#     - Optional: ARM_TEMPLATE_REF – branch/tag/SHA to fetch the ARM template from
+#       (default: master). CI sets this to the commit under test.
+#     - Optional: ARM_TEMPLATE_URI – full template URL, overrides ARM_TEMPLATE_REF.
+#     - Optional: RG_NAME – override the e2e resource group name.
 #
 # Usage:
 #   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
@@ -31,7 +35,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
-ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/BlobViaEventGrid/ARM/BlobViaEventGrid.json"
+# Defaults to master so a local run needs no setup; CI overrides ARM_TEMPLATE_REF
+# with the commit under test so the template being validated is the one changed.
+ARM_TEMPLATE_REF="${ARM_TEMPLATE_REF:-master}"
+ARM_TEMPLATE_URI="${ARM_TEMPLATE_URI:-https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/${ARM_TEMPLATE_REF}/BlobViaEventGrid/ARM/BlobViaEventGrid.json}"
 
 # Required
 : "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
@@ -46,6 +53,11 @@ CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-blob-storage-eventgrid-e2e}"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
+# Known up front (not read from terraform output) so the cleanup trap below can
+# still tear down the resource group when `terraform apply` fails part-way.
+# Must match the default of var.resource_group_name in tests/terraform.
+RG_NAME="${RG_NAME:-blobviaeg-e2e-rg}"
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
@@ -55,12 +67,19 @@ cleanup_after_failure() {
 trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
+# An aborted earlier run can leave the resource group behind, and because the
+# name is deterministic that makes every later `terraform apply` fail with
+# "already exists". Clear it first, blocking, so the run starts clean.
+if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
+  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
+  az group delete --name "$RG_NAME" --yes
+fi
+
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, container)..."
 cd "$TERRAFORM_DIR"
 terraform init -input=false
-terraform apply -input=false -auto-approve
+terraform apply -input=false -auto-approve -var="resource_group_name=${RG_NAME}"
 
-RG_NAME=$(terraform output -raw resource_group_name)
 STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
 STORAGE_RG=$(terraform output -raw storage_account_resource_group)
 CONTAINER_NAME=$(terraform output -raw blob_container_name)
@@ -93,10 +112,27 @@ build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"
   echo '} }'
 } > "$PARAMS_FILE"
 
-az deployment group create \
-  --resource-group "$RG_NAME" \
-  --template-uri "$ARM_TEMPLATE_URI" \
-  --parameters "@${PARAMS_FILE}"
+# The template creates the Event Grid subscription in the same deployment as the
+# function app. Event Grid validates the webhook endpoint immediately, and if the
+# app has not finished pulling its package yet that probe 404s and the whole
+# deployment fails with "Webhook endpoint validation failed". Retrying is enough:
+# the app is warm by the second attempt, and the deployment is idempotent.
+ARM_DEPLOY_ATTEMPTS="${ARM_DEPLOY_ATTEMPTS:-3}"
+for attempt in $(seq 1 "$ARM_DEPLOY_ATTEMPTS"); do
+  if az deployment group create \
+      --resource-group "$RG_NAME" \
+      --template-uri "$ARM_TEMPLATE_URI" \
+      --parameters "@${PARAMS_FILE}"; then
+    break
+  fi
+  if [[ "$attempt" -eq "$ARM_DEPLOY_ATTEMPTS" ]]; then
+    err "ARM deployment failed after ${ARM_DEPLOY_ATTEMPTS} attempts."
+    rm -f "$PARAMS_FILE"
+    exit 1
+  fi
+  log "ARM deployment attempt ${attempt} failed (likely Event Grid webhook validation); retrying in 60s..."
+  sleep 60
+done
 
 rm -f "$PARAMS_FILE"
 log "ARM deployment completed."

--- a/BlobViaEventGrid/tests/e2e.sh
+++ b/BlobViaEventGrid/tests/e2e.sh
@@ -59,11 +59,22 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 # Must match the default of var.resource_group_name in tests/terraform.
 RG_NAME="${RG_NAME:-blobviaeg-e2e-rg}"
 
+# Terraform state here is disposable: every run provisions from scratch into a
+# resource group whose name is fixed. Carrying it between runs is not merely
+# useless but harmful -- it pins random_string.suffix, so the "random" storage
+# account name is reused, the recreated account lands on the identical resource
+# ID, and diagnostic settings Azure orphaned when the previous group was deleted
+# resurface as "already exists". Discard it whenever the group goes away.
+discard_terraform_state() {
+  rm -f "${TERRAFORM_DIR}/terraform.tfstate" "${TERRAFORM_DIR}/terraform.tfstate.backup"
+}
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi
+  discard_terraform_state
 }
 trap cleanup_after_failure EXIT
 
@@ -89,6 +100,11 @@ if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
   done
   log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
+
+# Nothing this harness provisions survives the sweep above, so any state still on
+# disk describes resources that no longer exist -- left behind by a run that died
+# before its own cleanup. Start from an empty state unconditionally.
+discard_terraform_state
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, container)..."
 cd "$TERRAFORM_DIR"
@@ -245,9 +261,5 @@ az group delete --name "$RG_NAME" --yes
 log "Waiting for resource group deletion..."
 while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
 # Clean Terraform state so next run can provision from scratch.
-cd "$TERRAFORM_DIR"
-while read -r state_key; do
-  [[ -z "$state_key" ]] && continue
-  terraform state rm "$state_key" 2>/dev/null || true
-done < <(terraform state list 2>/dev/null || true)
+discard_terraform_state
 log "E2E test finished."

--- a/BlobViaEventGrid/tests/terraform/main.tf
+++ b/BlobViaEventGrid/tests/terraform/main.tf
@@ -23,9 +23,17 @@ locals {
   location    = "westeurope"
 }
 
+# e2e.sh passes this so it knows the name before apply and can clean up a
+# partially-created group. Keep the default in sync with RG_NAME in e2e.sh.
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group holding the e2e prerequisites."
+  default     = "blobviaeg-e2e-rg"
+}
+
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)
 resource "azurerm_resource_group" "e2e" {
-  name     = "${local.name_prefix}-rg"
+  name     = var.resource_group_name
   location = local.location
 }
 

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -5,7 +5,8 @@
 # Order of execution:
 #   1. Provision Azure resources with Terraform (RG, Event Hub, storage account with
 #      diagnostic setting that streams Transaction metric to Event Hub).
-#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2. Deploy the ARM template at ARM_TEMPLATE_REF (default master) via Azure CLI,
+#      with explicit parameters from step 1.
 #   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Upload 5–10 blobs to the storage account to generate transactions; diagnostic setting
 #      streams data to Event Hub; function reads and forwards to Coralogix.
@@ -73,10 +74,24 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Provision with Terraform ---
 # An aborted earlier run can leave the resource group behind, and because the
 # name is deterministic that makes every later `terraform apply` fail with
-# "already exists". Clear it first, blocking, so the run starts clean.
+# "already exists". The failure path deletes with --no-wait, so the group may
+# also still be mid-delete from that run: request deletion (ignoring an error if
+# one is already in flight) and then wait until it has actually gone, rather than
+# assuming a blocking delete can start.
+PREFLIGHT_TIMEOUT_SECS="${PREFLIGHT_TIMEOUT_SECS:-600}"
 if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
-  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
-  az group delete --name "$RG_NAME" --yes
+  log "Pre-flight: resource group $RG_NAME is left over from an earlier run; removing it..."
+  az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  waited=0
+  while [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; do
+    if [[ "$waited" -ge "$PREFLIGHT_TIMEOUT_SECS" ]]; then
+      err "Pre-flight: $RG_NAME still present after ${PREFLIGHT_TIMEOUT_SECS}s. Delete it manually and re-run."
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, Event Hub, storage account + diagnostic setting)..."
@@ -93,11 +108,11 @@ CONTAINER_NAME=$(terraform output -raw blob_container_name)
 
 log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, Storage container=$CONTAINER_NAME"
 
-# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+# --- Step 2: Deploy the ARM template at ARM_TEMPLATE_REF with explicit parameters ---
 # DiagnosticData ARM expects CustomURL as the full Coralogix events URL (e.g. https://ingress.xxx/azure/events/v1)
 CORALOGIX_EVENTS_URL="${OTEL_ENDPOINT%/}/azure/events/v1"
 
-log "Step 2: Deploying ARM template from master (DiagnosticData function)..."
+log "Step 2: Deploying ARM template (ref: ${ARM_TEMPLATE_REF}) (DiagnosticData function)..."
 PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
 build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
 {

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -63,11 +63,22 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 # Must match the default of var.resource_group_name in tests/terraform.
 RG_NAME="${RG_NAME:-cx-diagdata-e2e-rg}"
 
+# Terraform state here is disposable: every run provisions from scratch into a
+# resource group whose name is fixed. Carrying it between runs is not merely
+# useless but harmful -- it pins random_string.suffix, so the "random" storage
+# account name is reused, the recreated account lands on the identical resource
+# ID, and diagnostic settings Azure orphaned when the previous group was deleted
+# resurface as "already exists". Discard it whenever the group goes away.
+discard_terraform_state() {
+  rm -f "${TERRAFORM_DIR}/terraform.tfstate" "${TERRAFORM_DIR}/terraform.tfstate.backup"
+}
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi
+  discard_terraform_state
 }
 trap cleanup_after_failure EXIT
 
@@ -93,6 +104,11 @@ if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
   done
   log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
+
+# Nothing this harness provisions survives the sweep above, so any state still on
+# disk describes resources that no longer exist -- left behind by a run that died
+# before its own cleanup. Start from an empty state unconditionally.
+discard_terraform_state
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, Event Hub, storage account + diagnostic setting)..."
 cd "$TERRAFORM_DIR"
@@ -236,9 +252,5 @@ az group delete --name "$RG_NAME" --yes
 log "Waiting for resource group deletion..."
 while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
 # Clean Terraform state so next run can provision from scratch.
-cd "$TERRAFORM_DIR"
-while read -r state_key; do
-  [[ -z "$state_key" ]] && continue
-  terraform state rm "$state_key" 2>/dev/null || true
-done < <(terraform state list 2>/dev/null || true)
+discard_terraform_state
 log "E2E test finished."

--- a/DiagnosticData/tests/e2e.sh
+++ b/DiagnosticData/tests/e2e.sh
@@ -21,6 +21,10 @@
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 (Data Usage API read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#     - Optional: ARM_TEMPLATE_REF – branch/tag/SHA to fetch the ARM template from
+#       (default: master). CI sets this to the commit under test.
+#     - Optional: ARM_TEMPLATE_URI – full template URL, overrides ARM_TEMPLATE_REF.
+#     - Optional: RG_NAME – override the e2e resource group name.
 #
 # Usage:
 #   export OTEL_ENDPOINT="https://ingress.eu1.coralogix.com"
@@ -32,7 +36,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
-ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/DiagnosticData/ARM/DiagnosticData.json"
+# Defaults to master so a local run needs no setup; CI overrides ARM_TEMPLATE_REF
+# with the commit under test so the template being validated is the one changed.
+ARM_TEMPLATE_REF="${ARM_TEMPLATE_REF:-master}"
+ARM_TEMPLATE_URI="${ARM_TEMPLATE_URI:-https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/${ARM_TEMPLATE_REF}/DiagnosticData/ARM/DiagnosticData.json}"
 
 # Number of blobs to upload to trigger storage transactions (diagnostic data streamed to Event Hub)
 NUM_BLOBS="${NUM_BLOBS:-8}"
@@ -50,6 +57,11 @@ CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-diagnosticdata-e2e}"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
+# Known up front (not read from terraform output) so the cleanup trap below can
+# still tear down the resource group when `terraform apply` fails part-way.
+# Must match the default of var.resource_group_name in tests/terraform.
+RG_NAME="${RG_NAME:-cx-diagdata-e2e-rg}"
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
@@ -59,12 +71,19 @@ cleanup_after_failure() {
 trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
+# An aborted earlier run can leave the resource group behind, and because the
+# name is deterministic that makes every later `terraform apply` fail with
+# "already exists". Clear it first, blocking, so the run starts clean.
+if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
+  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
+  az group delete --name "$RG_NAME" --yes
+fi
+
 log "Step 1: Provisioning Azure resources with Terraform (RG, Event Hub, storage account + diagnostic setting)..."
 cd "$TERRAFORM_DIR"
 terraform init -input=false
-terraform apply -input=false -auto-approve
+terraform apply -input=false -auto-approve -var="resource_group_name=${RG_NAME}"
 
-RG_NAME=$(terraform output -raw resource_group_name)
 EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
 EVENTHUB_NAME=$(terraform output -raw eventhub_name)
 EVENTHUB_RG=$(terraform output -raw eventhub_resource_group)

--- a/DiagnosticData/tests/terraform/main.tf
+++ b/DiagnosticData/tests/terraform/main.tf
@@ -30,9 +30,17 @@ locals {
   location    = "westeurope"
 }
 
+# e2e.sh passes this so it knows the name before apply and can clean up a
+# partially-created group. Keep the default in sync with RG_NAME in e2e.sh.
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group holding the e2e prerequisites."
+  default     = "cx-diagdata-e2e-rg"
+}
+
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)
 resource "azurerm_resource_group" "e2e" {
-  name     = "${local.name_prefix}-rg"
+  name     = var.resource_group_name
   location = local.location
 }
 

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -28,7 +28,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
-ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/EventHub/ARM/EventHubV2.json"
+# Defaults to master so a local run needs no setup; CI overrides ARM_TEMPLATE_REF
+# with the commit under test so the template being validated is the one changed.
+ARM_TEMPLATE_REF="${ARM_TEMPLATE_REF:-master}"
+ARM_TEMPLATE_URI="${ARM_TEMPLATE_URI:-https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/${ARM_TEMPLATE_REF}/EventHub/ARM/EventHubV2.json}"
 
 # Required
 : "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.eu1.coralogix.com)}"
@@ -42,6 +45,11 @@ CX_SUBSYS="${CORALOGIX_SUBSYSTEM:-eventhub-e2e}"
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
+# Known up front (not read from terraform output) so the cleanup trap below can
+# still tear down the resource group when `terraform apply` fails part-way.
+# Must match the default of var.resource_group_name in tests/terraform.
+RG_NAME="${RG_NAME:-cx-eventhub-e2e-rg}"
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
@@ -51,12 +59,19 @@ cleanup_after_failure() {
 trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
+# An aborted earlier run can leave the resource group behind, and because the
+# name is deterministic that makes every later `terraform apply` fail with
+# "already exists". Clear it first, blocking, so the run starts clean.
+if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
+  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
+  az group delete --name "$RG_NAME" --yes
+fi
+
 log "Step 1: Provisioning Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules)..."
 cd "$TERRAFORM_DIR"
 terraform init -input=false
-terraform apply -input=false -auto-approve
+terraform apply -input=false -auto-approve -var="resource_group_name=${RG_NAME}"
 
-RG_NAME=$(terraform output -raw resource_group_name)
 EVENTHUB_NAMESPACE=$(terraform output -raw eventhub_namespace)
 EVENTHUB_NAME=$(terraform output -raw eventhub_name)
 EVENTHUB_RG=$(terraform output -raw eventhub_resource_group)

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -4,7 +4,8 @@
 #
 # Order of execution:
 #   1. Provision Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules).
-#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2. Deploy the ARM template at ARM_TEMPLATE_REF (default master) via Azure CLI,
+#      with explicit parameters from step 1.
 #   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send test events to the Event Hub to trigger the function.
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
@@ -61,10 +62,24 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Provision with Terraform ---
 # An aborted earlier run can leave the resource group behind, and because the
 # name is deterministic that makes every later `terraform apply` fail with
-# "already exists". Clear it first, blocking, so the run starts clean.
+# "already exists". The failure path deletes with --no-wait, so the group may
+# also still be mid-delete from that run: request deletion (ignoring an error if
+# one is already in flight) and then wait until it has actually gone, rather than
+# assuming a blocking delete can start.
+PREFLIGHT_TIMEOUT_SECS="${PREFLIGHT_TIMEOUT_SECS:-600}"
 if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
-  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
-  az group delete --name "$RG_NAME" --yes
+  log "Pre-flight: resource group $RG_NAME is left over from an earlier run; removing it..."
+  az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  waited=0
+  while [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; do
+    if [[ "$waited" -ge "$PREFLIGHT_TIMEOUT_SECS" ]]; then
+      err "Pre-flight: $RG_NAME still present after ${PREFLIGHT_TIMEOUT_SECS}s. Delete it manually and re-run."
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
 
 log "Step 1: Provisioning Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules)..."
@@ -81,7 +96,7 @@ EVENTHUB_SEND_CONNECTION_STRING=$(terraform output -raw eventhub_send_connection
 
 log "Terraform outputs: RG=$RG_NAME, EventHub=$EVENTHUB_NAMESPACE/$EVENTHUB_NAME, ConsumerGroup=$EVENTHUB_CONSUMER_GROUP"
 
-# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
+# --- Step 2: Deploy the ARM template at ARM_TEMPLATE_REF with explicit parameters ---
 # EventHubV2 expects CustomURL as host:port (e.g. ingress.eu1.coralogix.com:443)
 CUSTOM_URL="${OTEL_ENDPOINT#*://}"
 CUSTOM_URL="${CUSTOM_URL%%/*}"
@@ -89,7 +104,7 @@ if [[ "$CUSTOM_URL" != *:* ]]; then
   CUSTOM_URL="${CUSTOM_URL}:443"
 fi
 
-log "Step 2: Deploying ARM template from master (EventHub function)..."
+log "Step 2: Deploying ARM template (ref: ${ARM_TEMPLATE_REF}) (EventHub function)..."
 PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
 build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }
 {

--- a/EventHub/tests/e2e.sh
+++ b/EventHub/tests/e2e.sh
@@ -51,11 +51,22 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 # Must match the default of var.resource_group_name in tests/terraform.
 RG_NAME="${RG_NAME:-cx-eventhub-e2e-rg}"
 
+# Terraform state here is disposable: every run provisions from scratch into a
+# resource group whose name is fixed. Carrying it between runs is not merely
+# useless but harmful -- it pins random_string.suffix, so the "random" storage
+# account name is reused, the recreated account lands on the identical resource
+# ID, and diagnostic settings Azure orphaned when the previous group was deleted
+# resurface as "already exists". Discard it whenever the group goes away.
+discard_terraform_state() {
+  rm -f "${TERRAFORM_DIR}/terraform.tfstate" "${TERRAFORM_DIR}/terraform.tfstate.backup"
+}
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi
+  discard_terraform_state
 }
 trap cleanup_after_failure EXIT
 
@@ -81,6 +92,11 @@ if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
   done
   log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
+
+# Nothing this harness provisions survives the sweep above, so any state still on
+# disk describes resources that no longer exist -- left behind by a run that died
+# before its own cleanup. Start from an empty state unconditionally.
+discard_terraform_state
 
 log "Step 1: Provisioning Azure resources with Terraform (Event Hub namespace, hub, consumer group, auth rules)..."
 cd "$TERRAFORM_DIR"
@@ -211,9 +227,5 @@ az group delete --name "$RG_NAME" --yes
 log "Waiting for resource group deletion..."
 while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
 # Clean Terraform state so next run can provision from scratch.
-cd "$TERRAFORM_DIR"
-while read -r state_key; do
-  [[ -z "$state_key" ]] && continue
-  terraform state rm "$state_key" 2>/dev/null || true
-done < <(terraform state list 2>/dev/null || true)
+discard_terraform_state
 log "E2E test finished."

--- a/EventHub/tests/terraform/main.tf
+++ b/EventHub/tests/terraform/main.tf
@@ -24,9 +24,17 @@ locals {
   location    = "westeurope"
 }
 
+# e2e.sh passes this so it knows the name before apply and can clean up a
+# partially-created group. Keep the default in sync with RG_NAME in e2e.sh.
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group holding the e2e prerequisites."
+  default     = "cx-eventhub-e2e-rg"
+}
+
 # Single resource group for the e2e test (prereqs; function is deployed via ARM)
 resource "azurerm_resource_group" "e2e" {
-  name     = "${local.name_prefix}-rg"
+  name     = var.resource_group_name
   location = local.location
 }
 

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -19,6 +19,10 @@
 #     - CORALOGIX_QUERY_API_KEY or CORALOGIX_API_KEY – for Step 4 verification (Data Usage read permission).
 #     - CORALOGIX_API_KEY or CORALOGIX_PRIVATE_KEY – used as Coralogix Private Key for the function.
 #     - Optional: CORALOGIX_APPLICATION, CORALOGIX_SUBSYSTEM
+#     - Optional: ARM_TEMPLATE_REF – branch/tag/SHA to fetch the ARM template from
+#       (default: master). CI sets this to the commit under test.
+#     - Optional: ARM_TEMPLATE_URI – full template URL, overrides ARM_TEMPLATE_REF.
+#     - Optional: RG_NAME – override the e2e resource group name.
 #
 # Usage:
 #   export OTEL_ENDPOINT="https://ingress.eu2.coralogix.com"
@@ -30,7 +34,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TERRAFORM_DIR="${SCRIPT_DIR}/terraform"
-ARM_TEMPLATE_URI="https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/master/StorageQueue/ARM/StorageQueue.json"
+# Defaults to master so a local run needs no setup; CI overrides ARM_TEMPLATE_REF
+# with the commit under test so the template being validated is the one changed.
+ARM_TEMPLATE_REF="${ARM_TEMPLATE_REF:-master}"
+ARM_TEMPLATE_URI="${ARM_TEMPLATE_URI:-https://raw.githubusercontent.com/coralogix/coralogix-azure-serverless/${ARM_TEMPLATE_REF}/StorageQueue/ARM/StorageQueue.json}"
 
 # Required
 : "${OTEL_ENDPOINT:?Set OTEL_ENDPOINT (e.g. https://ingress.coralogix.com)}"
@@ -51,6 +58,11 @@ fi
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
 err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 
+# Known up front (not read from terraform output) so the cleanup trap below can
+# still tear down the resource group when `terraform apply` fails part-way.
+# Must match the default of var.resource_group_name in tests/terraform.
+RG_NAME="${RG_NAME:-storagequeue-e2e-rg}"
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
@@ -60,12 +72,19 @@ cleanup_after_failure() {
 trap cleanup_after_failure EXIT
 
 # --- Step 1: Provision with Terraform ---
+# An aborted earlier run can leave the resource group behind, and because the
+# name is deterministic that makes every later `terraform apply` fail with
+# "already exists". Clear it first, blocking, so the run starts clean.
+if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
+  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
+  az group delete --name "$RG_NAME" --yes
+fi
+
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."
 cd "$TERRAFORM_DIR"
 terraform init -input=false
-terraform apply -input=false -auto-approve
+terraform apply -input=false -auto-approve -var="resource_group_name=${RG_NAME}"
 
-RG_NAME=$(terraform output -raw resource_group_name)
 STORAGE_ACCOUNT=$(terraform output -raw storage_account_name)
 STORAGE_RG=$(terraform output -raw storage_account_resource_group)
 STORAGE_QUEUE_NAME=$(terraform output -raw storage_queue_name)

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -64,11 +64,22 @@ err() { echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] ERROR: $*" >&2; }
 # Must match the default of var.resource_group_name in tests/terraform.
 RG_NAME="${RG_NAME:-storagequeue-e2e-rg}"
 
+# Terraform state here is disposable: every run provisions from scratch into a
+# resource group whose name is fixed. Carrying it between runs is not merely
+# useless but harmful -- it pins random_string.suffix, so the "random" storage
+# account name is reused, the recreated account lands on the identical resource
+# ID, and diagnostic settings Azure orphaned when the previous group was deleted
+# resurface as "already exists". Discard it whenever the group goes away.
+discard_terraform_state() {
+  rm -f "${TERRAFORM_DIR}/terraform.tfstate" "${TERRAFORM_DIR}/terraform.tfstate.backup"
+}
+
 cleanup_after_failure() {
   log "Cleaning up after failure..."
   if [[ -n "${RG_NAME:-}" ]]; then
     az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
   fi
+  discard_terraform_state
 }
 trap cleanup_after_failure EXIT
 
@@ -94,6 +105,11 @@ if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
   done
   log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
+
+# Nothing this harness provisions survives the sweep above, so any state still on
+# disk describes resources that no longer exist -- left behind by a run that died
+# before its own cleanup. Start from an empty state unconditionally.
+discard_terraform_state
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."
 cd "$TERRAFORM_DIR"
@@ -212,9 +228,5 @@ az group delete --name "$RG_NAME" --yes
 log "Waiting for resource group deletion..."
 while az group show -n "$RG_NAME" &>/dev/null; do sleep 10; done
 # Clean Terraform state so next run can provision from scratch.
-cd "$TERRAFORM_DIR"
-while read -r state_key; do
-  [[ -z "$state_key" ]] && continue
-  terraform state rm "$state_key" 2>/dev/null || true
-done < <(terraform state list 2>/dev/null || true)
+discard_terraform_state
 log "E2E test finished."

--- a/StorageQueue/tests/e2e.sh
+++ b/StorageQueue/tests/e2e.sh
@@ -4,7 +4,8 @@
 #
 # Order of execution:
 #   1. Provision Azure resources with Terraform (resource group, StorageV2 account, queue).
-#   2. Deploy ARM template (latest master) via Azure CLI with explicit parameters from step 1.
+#   2. Deploy the ARM template at ARM_TEMPLATE_REF (default master) via Azure CLI,
+#      with explicit parameters from step 1.
 #   2c. Sync function triggers (az resource invoke-action), then wait 15s.
 #   3. Send a test payload (put a JSON message into the storage queue to trigger the function).
 #   4. Wait 30s, then poll Coralogix Get Logs Count API until count > 0 (retry every 30s, up to 30 times).
@@ -74,10 +75,24 @@ trap cleanup_after_failure EXIT
 # --- Step 1: Provision with Terraform ---
 # An aborted earlier run can leave the resource group behind, and because the
 # name is deterministic that makes every later `terraform apply` fail with
-# "already exists". Clear it first, blocking, so the run starts clean.
+# "already exists". The failure path deletes with --no-wait, so the group may
+# also still be mid-delete from that run: request deletion (ignoring an error if
+# one is already in flight) and then wait until it has actually gone, rather than
+# assuming a blocking delete can start.
+PREFLIGHT_TIMEOUT_SECS="${PREFLIGHT_TIMEOUT_SECS:-600}"
 if [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; then
-  log "Pre-flight: removing stale resource group $RG_NAME left by an earlier run..."
-  az group delete --name "$RG_NAME" --yes
+  log "Pre-flight: resource group $RG_NAME is left over from an earlier run; removing it..."
+  az group delete --name "$RG_NAME" --yes --no-wait 2>/dev/null || true
+  waited=0
+  while [[ "$(az group exists --name "$RG_NAME")" == "true" ]]; do
+    if [[ "$waited" -ge "$PREFLIGHT_TIMEOUT_SECS" ]]; then
+      err "Pre-flight: $RG_NAME still present after ${PREFLIGHT_TIMEOUT_SECS}s. Delete it manually and re-run."
+      exit 1
+    fi
+    sleep 10
+    waited=$((waited + 10))
+  done
+  log "Pre-flight: $RG_NAME removed after ${waited}s."
 fi
 
 log "Step 1: Provisioning Azure resources with Terraform (RG, StorageV2, queue)..."
@@ -92,8 +107,8 @@ STORAGE_CONNECTION_STRING=$(terraform output -raw storage_account_connection_str
 
 log "Terraform outputs: RG=$RG_NAME, Storage=$STORAGE_ACCOUNT, Queue=$STORAGE_QUEUE_NAME"
 
-# --- Step 2: Deploy ARM template (latest master) with explicit parameters ---
-log "Step 2: Deploying ARM template from master (function + queue trigger)..."
+# --- Step 2: Deploy the ARM template at ARM_TEMPLATE_REF with explicit parameters ---
+log "Step 2: Deploying ARM template (ref: ${ARM_TEMPLATE_REF}) (function + queue trigger)..."
 PARAMS_FILE="${SCRIPT_DIR}/arm-params.json"
 # Build parameters JSON; escape quotes in values.
 build_param() { echo "\"$1\": { \"value\": \"$(echo "$2" | sed 's/\\/\\\\/g; s/"/\\"/g')\" }"; }

--- a/StorageQueue/tests/terraform/main.tf
+++ b/StorageQueue/tests/terraform/main.tf
@@ -24,9 +24,17 @@ locals {
   location    = "westeurope"
 }
 
+# e2e.sh passes this so it knows the name before apply and can clean up a
+# partially-created group. Keep the default in sync with RG_NAME in e2e.sh.
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group holding the e2e prerequisites."
+  default     = "storagequeue-e2e-rg"
+}
+
 # Single resource group for the e2e test (prereqs; function is deployed via ARM into this RG)
 resource "azurerm_resource_group" "e2e" {
-  name     = "${local.name_prefix}-rg"
+  name     = var.resource_group_name
   location = local.location
 }
 


### PR DESCRIPTION
# Description

The e2e harness already existed for all five packages, but it could only ever run for **EventHub** and **BlobToOtel**, and three of the five were failing. This makes the suite actually usable as a gate — which is the prerequisite for versioning the three unversioned functions.

State over the last 5 release-triggered runs before this PR:

| Package | Result |
|---|---|
| EventHub | 5/5 ✅ |
| StorageQueue | 5/5 ✅ |
| BlobViaEventGrid | 4/5 |
| BlobToOtel | 2/5 (regressed) |
| DiagnosticData | 0/5 — has never passed |

## Wiring

- `e2e.yaml` declared only a `workflow_run` trigger on *Build, Test & Release*, which only fires for `EventHub/**` and `BlobToOtel/**`. So a change to the other three triggered **no e2e at all**. The `push` and `workflow_dispatch` branches were already implemented in `detect-changes`, but neither trigger was declared in `on:` — dead code. Both are now declared, with `push` scoped to the three packages that have no release workflow of their own.
- `workflow_dispatch` takes a package picker so a single package can be run on demand.
- Checkout and the new `ARM_TEMPLATE_REF` pin to the triggering commit, so the suite deploys **the ARM template under test** rather than always fetching master. Defaults to `master` so local runs need no setup.
- A `concurrency` group serialises runs: the e2e resource group names are deterministic and the new pre-flight sweep deletes a stale group by name, so overlapping runs would tear down each other's resources.

## Failures fixed

**DiagnosticData (0/5).** An ordering bug present in all five scripts: `RG_NAME` was assigned *after* `terraform apply`, but the cleanup trap was installed *before* it. When apply failed part-way, `RG_NAME` was unset, the trap silently did nothing, and the orphaned resource group made every subsequent run fail with `A resource with the ID ".../cx-diagdata-e2e-rg" already exists`. Self-perpetuating since March.

Fix: set the name before the trap, pass it to Terraform as `var.resource_group_name`, and sweep a pre-existing group pre-flight (blocking) so no run can be blocked by a previous one. Self-healing — no manual Azure cleanup needed.

**BlobViaEventGrid (4/5).** `Webhook endpoint validation failed ... StatusCode: NotFound`. The template creates the Event Grid subscription in the same deployment as the function app; Event Grid probes the webhook immediately and 404s while the app is still pulling its package. Retry the deployment — it's idempotent and the app is warm by the second attempt.

**BlobToOtel (2/5) — not fixed here.** Its `packageUri` points at `BlobToOtel-v3.0.2`, a release that was never published (introduced by #112 on 2026-05-18, exactly when e2e started failing). ARM doesn't validate the URL, so the deployment succeeds but the app has no fetchable package and sync-triggers returns `Bad Request`. #117 repairs that URL by bumping to v3.2.0.

## Also included

`**/tests/**` added to `build.yaml`'s ignore list. Without it, merging this test-only PR would rebuild and overwrite the three production S3 artifacts that `BlobViaEventGrid`, `DiagnosticData` and `StorageQueue` deployments run from.

# How Has This Been Tested?

- `bash -n` on all five scripts.
- `shellcheck -S warning` clean across all five.
- `terraform validate` passes on all five harnesses; `terraform fmt -check -recursive` clean.
- Both workflow YAMLs parse; trigger and concurrency structure verified.

**Not yet run against live Azure** — that needs the OIDC secrets, which is why this is a draft. Two things to watch on the first real run:

1. The orphaned `cx-diagdata-e2e-rg` should be swept automatically, but if Azure has it in a stuck deleting state the delete may still be rejected.
2. DiagnosticData has never gotten past step 1, so there may be a second failure behind the orphan — see the `document the DiagnosticsData test instability` commit from March. One green DiagnosticData run is the real acceptance criterion for this PR, not the diff.

Commit type is `ci(...)` deliberately: it touches `EventHub/**` and `BlobToOtel/**`, and a releasing type would cut pointless versions of both for a test-only change.

# Checklist:
- [ ] I have updated the version in the relevant file.
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)