### PR TITLE
ci(BlobToOtel): point packageUri at the published v3.1.0 release

### DIFF
--- a/BlobToOtel/ARM/BlobToOtel.json
+++ b/BlobToOtel/ARM/BlobToOtel.json
@@ -168,7 +168,7 @@
     "applicationInsightsName": "[variables('functionAppName')]",
     "functionStorageAccountName": "[format('func{0}', uniqueString(resourceGroup().id))]",
     "sku": "[if(equals(parameters('FunctionAppServicePlanType'), 'Consumption'), 'Y1', parameters('PremiumPlanSku'))]",
-    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.0.2/BlobToOtel-FunctionApp.zip",
+    "packageUri": "https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.1.0/BlobToOtel-FunctionApp.zip",
     "vnetIntegrationEnabled": "[and(not(empty(parameters('VirtualNetworkName'))), not(empty(parameters('SubnetName'))))]"
   },
   "resources": [


### PR DESCRIPTION
# Description

`BlobToOtel/ARM/BlobToOtel.json` deploys the function app from `BlobToOtel-v3.0.2` — **a release that was never published**. The published tags go `v3.0.1` → `v3.1.0`:

```
$ gh release list | grep BlobToOtel
BlobToOtel-v3.1.0   2026-05-18
BlobToOtel-v3.0.1   2026-02-06
BlobToOtel-v3.0.0   2026-02-06
BlobToOtel-v2.6.0   2026-02-06
```

ARM does not validate `packageUri`, so the deployment reports **success** and the function app is simply left with no fetchable package. The failure only surfaces at the next step, as a `sync-triggers` error that gives no hint about the real cause:

```
ERROR: Operation returned an invalid status 'Bad Request'
```

This is the BlobToOtel e2e failure on every master run since 2026-05-18 — the same day the bad value landed. Latest occurrence: [run 29731030679](https://github.com/coralogix/coralogix-azure-serverless/actions/runs/29731030679).

## Root cause

`packageUri` is hand-edited; the tag is computed by `semantic-release` (`release.config.js`, `tagFormat: 'BlobToOtel-v${version}'`). #112 hand-wrote `v3.0.2` to match its own `package.json` bump, while semantic-release independently derived `v3.1.0` from the commit history.

Nothing keeps the two in sync, so the pointer is only ever correct by coincidence. This PR repairs the current value; **deriving it automatically is worth a follow-up.**

## Why `ci(...)` and not `fix(...)`

A releasing type would cut `v3.1.1` from this change, and `packageUri` would immediately be pointing one release behind again. `ci` is not a releasing type under the default commit-analyzer preset, so `v3.1.0` stays current and the pointer stays correct.

## Scope

I checked the other four templates for the same class of breakage:

| Template | Source | Status |
|---|---|---|
| `BlobToOtel/ARM/BlobToOtel.json` | `BlobToOtel-v3.0.2` | ❌ does not exist — fixed here |
| `EventHub/ARM/EventHubV2.json` | `EventHub-v3.8.3` | ✅ current |
| `EventHub/ARM/EventHub.json` | S3 | n/a |
| `DiagnosticData`, `StorageQueue`, `BlobViaEventGrid` | S3 | n/a |

BlobToOtel was the only one affected.

# How Has This Been Tested?

The corrected URL resolves to a real asset:

```
$ curl -sSI -L https://github.com/coralogix/coralogix-azure-serverless/releases/download/BlobToOtel-v3.1.0/BlobToOtel-FunctionApp.zip
HTTP/2 200
content-length: 21089299
```

A full BlobToOtel e2e run needs this on `master` first, since the harness fetches the ARM template over HTTPS by ref — that verification follows in #118.

# Checklist:
- [ ] I have updated the version in the relevant file.
- [ ] I have updated the relevant component changelog(s)
- [x] This change does not affect any particular component (e.g. it's readme or docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)